### PR TITLE
Avoid breaking current directory on neovim

### DIFF
--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -50,7 +50,7 @@ endfunction
 function! magit#git#is_work_tree(path)
 	let dir = getcwd()
 	try
-		call magit#utils#lcd(a:path)
+		call magit#utils#chdir(a:path)
 		let top_dir=magit#utils#strip(
 					\ system(g:magit_git_cmd . " rev-parse --show-toplevel")) . "/"
 		if ( v:shell_error != 0 )
@@ -58,7 +58,7 @@ function! magit#git#is_work_tree(path)
 		endif
 		return top_dir
 	finally
-		call magit#utils#lcd(dir)
+		call magit#utils#chdir(dir)
 	endtry
 endfunction
 
@@ -68,7 +68,7 @@ endfunction
 function! magit#git#set_top_dir(path)
 	let dir = getcwd()
 	try
-		call magit#utils#lcd(a:path)
+		call magit#utils#chdir(a:path)
 		let top_dir=magit#utils#strip(
 					\ system(g:magit_git_cmd . " rev-parse --show-toplevel")) . "/"
 		if ( v:shell_error != 0 )
@@ -81,7 +81,7 @@ function! magit#git#set_top_dir(path)
 		let b:magit_top_dir=top_dir
 		let b:magit_git_dir=git_dir
 	finally
-		call magit#utils#lcd(dir)
+		call magit#utils#chdir(dir)
 	endtry
 endfunction
 

--- a/autoload/magit/state.vim
+++ b/autoload/magit/state.vim
@@ -274,7 +274,7 @@ function! magit#state#update() dict
 
 	let dir = getcwd()
 	try
-		call magit#utils#lcd(magit#git#top_dir())
+		call magit#utils#chdir(magit#git#top_dir())
 		call magit#utils#refresh_submodule_list()
 		for [mode, diff_dict_mode] in items(self.dict)
 			let status_list = magit#git#get_status()
@@ -289,7 +289,7 @@ function! magit#state#update() dict
 			endfor
 		endfor
 	finally
-		call magit#utils#lcd(dir)
+		call magit#utils#chdir(dir)
 	endtry
 
 	" remove files that have changed their mode or been committed/deleted/discarded...


### PR DESCRIPTION
Neovim allows a `tab-local` directory. The previous directory change function was breaking tab local directory configuration, changing it with `cd`.

This PR fixes the problem.
