### PR TITLE
Apply vint linting suggestions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,11 +61,11 @@ install:
     fi
 
 before_script:
-  - git clone https://github.com/jreybert/djooks
+  - git clone https://github.com/jreybert/djooks "djooks with spaces"
   - git clone https://github.com/jreybert/vader.vim
 
 script:
-  - ./test/run.sh . vader.vim djooks $VIM_VERSION
+  - ./test/run.sh . vader.vim "djooks with spaces" $VIM_VERSION
 
 after_success:
   - ./test/merge.sh

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Open magit buffer with [:Magit](#magitshow_magit) command.
 
 #### CC
 
-Once you have stage all the required changes, press **CC**. A new section "Commit message" appears and cursor move to it. Type your commit message, in Insert mode this time. Once it's done, go back in Normal mode, and press **CC**: you created your first commit with vimagit!
+Once you have stage all the required changes, type **CC**. A new section "Commit message" appears and cursor move to it. Type your commit message, in Insert mode this time. Once it's done, write your commit message with :w (or :x, :wq, ZZ).
+
+Voila! you created your first commit with vimagit!
 
 ## Usage
 
@@ -204,11 +206,13 @@ E means 'edit'.
 
 ##### CC
  * If not in commit section, set commit mode to "New commit" and show "Commit message" section with brand new commit message.
- * If in commit section, commit the all staged changes in commit mode previously set.
+ * If in commit section, create the commit with the commit message and all staged changes.
+
+##### :w :x :wq ZZ
+ * If in commit section, create the commit with the commit message and all staged changes.
 
 ##### CA
  * If not in commit section, set commit mode to "Amend commit" and show "Commit message" section with previous commit message.
- * If in commit section, commit the staged changes in commit mode previously set.
 
 ##### CF
  * Amend the staged changes into the previous commit, without modifying previous commit message.

--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -50,7 +50,7 @@ endfunction
 function! magit#git#is_work_tree(path)
 	let dir = getcwd()
 	try
-		call magit#utils#lcd(a:path)
+		call magit#utils#chdir(a:path)
 		let top_dir=magit#utils#strip(
 					\ system(g:magit_git_cmd . " rev-parse --show-toplevel")) . "/"
 		if ( v:shell_error != 0 )
@@ -58,7 +58,7 @@ function! magit#git#is_work_tree(path)
 		endif
 		return top_dir
 	finally
-		call magit#utils#lcd(dir)
+		call magit#utils#chdir(dir)
 	endtry
 endfunction
 
@@ -68,7 +68,7 @@ endfunction
 function! magit#git#set_top_dir(path)
 	let dir = getcwd()
 	try
-		call magit#utils#lcd(a:path)
+		call magit#utils#chdir(a:path)
 		let top_dir=magit#utils#strip(
 					\ system(g:magit_git_cmd . " rev-parse --show-toplevel")) . "/"
 		if ( v:shell_error != 0 )
@@ -81,7 +81,7 @@ function! magit#git#set_top_dir(path)
 		let b:magit_top_dir=top_dir
 		let b:magit_git_dir=git_dir
 	finally
-		call magit#utils#lcd(dir)
+		call magit#utils#chdir(dir)
 	endtry
 endfunction
 

--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -113,15 +113,14 @@ endfunction
 " return: two values
 "        [0]: boolean, if true current file is binary
 "        [1]: string array containing diff output
-function! magit#git#git_diff(filename, status, mode)
-	let dev_null = ( a:status == '?' ) ? "/dev/null " : ""
-	let staged_flag = ( a:mode == 'staged' ) ? "--staged" : ""
 function! magit#git#git_diff(filename, status, mode) abort
+	let dev_null = ( a:status ==# '?' ) ? "/dev/null " : ""
+	let staged_flag = ( a:mode ==# 'staged' ) ? "--staged" : ""
 	let git_cmd=g:magit_git_cmd . " diff --no-ext-diff " . staged_flag .
 				\ " --no-color -p -U" . b:magit_diff_context .
 				\ " -- " . dev_null . " " . a:filename
 	silent let diff_list=magit#utils#systemlist(git_cmd)
-	if ( a:status != '?' && v:shell_error != 0 )
+	if ( a:status !=# '?' && v:shell_error != 0 )
 		echohl WarningMsg
 		echom "Git error: " . string(diff_list)
 		echom "Git cmd: " . git_cmd
@@ -135,7 +134,7 @@ function! magit#git#git_diff(filename, status, mode) abort
 		throw 'diff error'
 	endif
 	return [
-		\ ( diff_list[-1] =~ "^Binary files .* differ$" && len(diff_list) <= 4 )
+		\ ( diff_list[-1] =~# "^Binary files .* differ$" && len(diff_list) <= 4 )
 		\, diff_list ]
 endfunction
 
@@ -143,9 +142,8 @@ endfunction
 " untracked content
 " param[in] submodule: submodule path
 " param[in] check_level: can be modified or untracked
-function! magit#git#sub_check(submodule, check_level)
-	let ignore_flag = ( a:check_level == 'modified' ) ?
 function! magit#git#sub_check(submodule, check_level) abort
+	let ignore_flag = ( a:check_level ==# 'modified' ) ?
 				\ '--ignore-submodules=untracked' : ''
 	let git_cmd=g:magit_git_cmd . " status --porcelain " . ignore_flag . " " . a:submodule
 	return ( !empty(magit#utils#systemlist(git_cmd)) )
@@ -156,14 +154,13 @@ endfunction
 " message is raised.
 " param[in] filemane: it must be quoted if it contains spaces
 " param[in] mode: can be staged or unstaged
-function! magit#git#git_sub_summary(filename, mode)
-	let staged_flag = ( a:mode == 'staged' ) ? " --cached " : " --files "
 function! magit#git#git_sub_summary(filename, mode) abort
+	let staged_flag = ( a:mode ==# 'staged' ) ? " --cached " : " --files "
 	let git_cmd=g:magit_git_cmd . " submodule summary " . staged_flag . " HEAD "
 				\ .a:filename
 	silent let diff_list=magit#utils#systemlist(git_cmd)
 	if ( empty(diff_list) )
-		if ( a:mode == 'unstaged' )
+		if ( a:mode ==# 'unstaged' )
 			if ( magit#git#sub_check(a:filename, 'modified') )
 				return "modified content"
 			endif
@@ -233,10 +230,9 @@ endfunction
 " param[in] selection: the text to stage. It must be a patch, i.e. a diff 
 " header plus one or more hunks
 " return: no
-function! magit#git#git_apply(header, selection)
 function! magit#git#git_apply(header, selection) abort
 	let selection = magit#utils#flatten(a:header + a:selection)
-	if ( selection[-1] !~ '^$' )
+	if ( selection[-1] !~# '^$' )
 		let selection += [ '' ]
 	endif
 	let git_cmd=g:magit_git_cmd . " apply --recount --no-index --cached -"
@@ -258,14 +254,13 @@ endfunction
 " param[in] selection: the text to stage. It must be a patch, i.e. a diff 
 " header plus one or more hunks
 " return: no
-function! magit#git#git_unapply(header, selection, mode)
 function! magit#git#git_unapply(header, selection, mode) abort
 	let cached_flag=''
-	if ( a:mode == 'staged' )
+	if ( a:mode ==# 'staged' )
 		let cached_flag=' --cached '
 	endif
 	let selection = magit#utils#flatten(a:header + a:selection)
-	if ( selection[-1] !~ '^$' )
+	if ( selection[-1] !~# '^$' )
 		let selection += [ '' ]
 	endif
 	silent let git_result=magit#utils#system(

--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -1,4 +1,4 @@
-function! magit#git#get_version()
+function! magit#git#get_version() abort
 	if ( !exists("s:git_version") )
 		let s:git_version = matchlist(system(g:magit_git_cmd . " --version"),
 		\ 'git version \(\d\+\)\.\(\d\+\)\.\(\d\+\)\.\(\d\+\)\.\(g\x\+\)')[1:5]
@@ -6,7 +6,7 @@ function! magit#git#get_version()
 	return s:git_version
 endfunction
 
-function! magit#git#is_version_sup_equal(major, minor, rev)
+function! magit#git#is_version_sup_equal(major, minor, rev) abort
 	let git_ver = magit#git#get_version()
 	return ( ( a:major > git_ver[0] ) ||
 			\ (a:major >= git_ver[0] && a:minor > git_ver[1] ) ||
@@ -17,7 +17,7 @@ endfunction
 " magit#git#get_status: this function returns the git status output formated
 " into a List of Dict as
 " [ {staged', 'unstaged', 'filename'}, ... ]
-function! magit#git#get_status()
+function! magit#git#get_status() abort
 	let file_list = []
 
 	" systemlist v7.4.248 problem again
@@ -33,7 +33,7 @@ function! magit#git#get_status()
 	return file_list
 endfunction
 
-function! magit#git#get_config(conf_name, default)
+function! magit#git#get_config(conf_name, default) abort
 	silent! let git_result=magit#utils#strip(
 				\ magit#utils#system(g:magit_git_cmd . " config --get " . a:conf_name))
 	if ( v:shell_error != 0 )
@@ -47,7 +47,7 @@ endfunction
 " inside a git work tree
 " param[in] path: path to check
 " return: top work tree path if in a work tree, empty string otherwise
-function! magit#git#is_work_tree(path)
+function! magit#git#is_work_tree(path) abort
 	let dir = getcwd()
 	try
 		call magit#utils#chdir(a:path)
@@ -65,7 +65,7 @@ endfunction
 " magit#git#set_top_dir: this function set b:magit_top_dir and b:magit_git_dir 
 " according to a path
 " param[in] path: path to set. This path must be in a git repository work tree
-function! magit#git#set_top_dir(path)
+function! magit#git#set_top_dir(path) abort
 	let dir = getcwd()
 	try
 		call magit#utils#chdir(a:path)
@@ -88,7 +88,7 @@ endfunction
 " magit#git#top_dir: return the absolute path of current git worktree for the
 " current magit buffer
 " return top directory
-function! magit#git#top_dir()
+function! magit#git#top_dir() abort
 	if ( !exists("b:magit_top_dir") )
 		throw 'top_dir_not_set'
 	endif
@@ -97,7 +97,7 @@ endfunction
 
 " magit#git#git_dir: return the absolute path of current git worktree
 " return git directory
-function! magit#git#git_dir()
+function! magit#git#git_dir() abort
 	if ( !exists("b:magit_git_dir") )
 		throw 'git_dir_not_set'
 	endif
@@ -116,6 +116,7 @@ endfunction
 function! magit#git#git_diff(filename, status, mode)
 	let dev_null = ( a:status == '?' ) ? "/dev/null " : ""
 	let staged_flag = ( a:mode == 'staged' ) ? "--staged" : ""
+function! magit#git#git_diff(filename, status, mode) abort
 	let git_cmd=g:magit_git_cmd . " diff --no-ext-diff " . staged_flag .
 				\ " --no-color -p -U" . b:magit_diff_context .
 				\ " -- " . dev_null . " " . a:filename
@@ -144,6 +145,7 @@ endfunction
 " param[in] check_level: can be modified or untracked
 function! magit#git#sub_check(submodule, check_level)
 	let ignore_flag = ( a:check_level == 'modified' ) ?
+function! magit#git#sub_check(submodule, check_level) abort
 				\ '--ignore-submodules=untracked' : ''
 	let git_cmd=g:magit_git_cmd . " status --porcelain " . ignore_flag . " " . a:submodule
 	return ( !empty(magit#utils#systemlist(git_cmd)) )
@@ -156,6 +158,7 @@ endfunction
 " param[in] mode: can be staged or unstaged
 function! magit#git#git_sub_summary(filename, mode)
 	let staged_flag = ( a:mode == 'staged' ) ? " --cached " : " --files "
+function! magit#git#git_sub_summary(filename, mode) abort
 	let git_cmd=g:magit_git_cmd . " submodule summary " . staged_flag . " HEAD "
 				\ .a:filename
 	silent let diff_list=magit#utils#systemlist(git_cmd)
@@ -180,7 +183,7 @@ endfunction
 " nota: when git fail (due to misformated patch for example), an error
 " message is raised.
 " param[in] filemane: it must be quoted if it contains spaces
-function! magit#git#git_add(filename)
+function! magit#git#git_add(filename) abort
 	let git_cmd=g:magit_git_cmd . " add --no-ignore-removal -- " . a:filename
 	silent let git_result=magit#utils#system(git_cmd)
 	if ( v:shell_error != 0 )
@@ -196,7 +199,7 @@ endfunction
 " nota: when git fail (due to misformated patch for example), an error
 " message is raised.
 " param[in] filemane: it must be quoted if it contains spaces
-function! magit#git#git_checkout(filename)
+function! magit#git#git_checkout(filename) abort
 	let git_cmd=g:magit_git_cmd . " checkout -- " . a:filename
 	silent let git_result=magit#utils#system(git_cmd)
 	if ( v:shell_error != 0 )
@@ -212,7 +215,7 @@ endfunction
 " nota: when git fail (due to misformated patch for example), an error
 " message is raised.
 " param[in] filemane: it must be quoted if it contains spaces
-function! magit#git#git_reset(filename)
+function! magit#git#git_reset(filename) abort
 	let git_cmd=g:magit_git_cmd . " reset HEAD -- " . a:filename
 	silent let git_result=magit#utils#system(git_cmd)
 	if ( v:shell_error != 0 )
@@ -231,6 +234,7 @@ endfunction
 " header plus one or more hunks
 " return: no
 function! magit#git#git_apply(header, selection)
+function! magit#git#git_apply(header, selection) abort
 	let selection = magit#utils#flatten(a:header + a:selection)
 	if ( selection[-1] !~ '^$' )
 		let selection += [ '' ]
@@ -255,6 +259,7 @@ endfunction
 " header plus one or more hunks
 " return: no
 function! magit#git#git_unapply(header, selection, mode)
+function! magit#git#git_unapply(header, selection, mode) abort
 	let cached_flag=''
 	if ( a:mode == 'staged' )
 		let cached_flag=' --cached '
@@ -276,6 +281,6 @@ function! magit#git#git_unapply(header, selection, mode)
 	endif
 endfunction
 
-function! magit#git#submodule_status()
+function! magit#git#submodule_status() abort
 	return system(g:magit_git_cmd . " submodule status")
 endfunction

--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -1,4 +1,4 @@
-function! magit#git#get_version()
+function! magit#git#get_version() abort
 	if ( !exists("s:git_version") )
 		let s:git_version = matchlist(system(g:magit_git_cmd . " --version"),
 		\ 'git version \(\d\+\)\.\(\d\+\)\.\(\d\+\)\.\(\d\+\)\.\(g\x\+\)')[1:5]
@@ -6,7 +6,7 @@ function! magit#git#get_version()
 	return s:git_version
 endfunction
 
-function! magit#git#is_version_sup_equal(major, minor, rev)
+function! magit#git#is_version_sup_equal(major, minor, rev) abort
 	let git_ver = magit#git#get_version()
 	return ( ( a:major > git_ver[0] ) ||
 			\ (a:major >= git_ver[0] && a:minor > git_ver[1] ) ||
@@ -17,7 +17,7 @@ endfunction
 " magit#git#get_status: this function returns the git status output formated
 " into a List of Dict as
 " [ {staged', 'unstaged', 'filename'}, ... ]
-function! magit#git#get_status()
+function! magit#git#get_status() abort
 	let file_list = []
 
 	" systemlist v7.4.248 problem again
@@ -33,7 +33,7 @@ function! magit#git#get_status()
 	return file_list
 endfunction
 
-function! magit#git#get_config(conf_name, default)
+function! magit#git#get_config(conf_name, default) abort
 	silent! let git_result=magit#utils#strip(
 				\ magit#utils#system(g:magit_git_cmd . " config --get " . a:conf_name))
 	if ( v:shell_error != 0 )
@@ -47,7 +47,7 @@ endfunction
 " inside a git work tree
 " param[in] path: path to check
 " return: top work tree path if in a work tree, empty string otherwise
-function! magit#git#is_work_tree(path)
+function! magit#git#is_work_tree(path) abort
 	let dir = getcwd()
 	try
 		call magit#utils#chdir(a:path)
@@ -65,7 +65,7 @@ endfunction
 " magit#git#set_top_dir: this function set b:magit_top_dir and b:magit_git_dir 
 " according to a path
 " param[in] path: path to set. This path must be in a git repository work tree
-function! magit#git#set_top_dir(path)
+function! magit#git#set_top_dir(path) abort
 	let dir = getcwd()
 	try
 		call magit#utils#chdir(a:path)
@@ -88,7 +88,7 @@ endfunction
 " magit#git#top_dir: return the absolute path of current git worktree for the
 " current magit buffer
 " return top directory
-function! magit#git#top_dir()
+function! magit#git#top_dir() abort
 	if ( !exists("b:magit_top_dir") )
 		throw 'top_dir_not_set'
 	endif
@@ -97,7 +97,7 @@ endfunction
 
 " magit#git#git_dir: return the absolute path of current git worktree
 " return git directory
-function! magit#git#git_dir()
+function! magit#git#git_dir() abort
 	if ( !exists("b:magit_git_dir") )
 		throw 'git_dir_not_set'
 	endif
@@ -113,14 +113,14 @@ endfunction
 " return: two values
 "        [0]: boolean, if true current file is binary
 "        [1]: string array containing diff output
-function! magit#git#git_diff(filename, status, mode)
-	let dev_null = ( a:status == '?' ) ? "/dev/null " : ""
-	let staged_flag = ( a:mode == 'staged' ) ? "--staged" : ""
+function! magit#git#git_diff(filename, status, mode) abort
+	let dev_null = ( a:status ==# '?' ) ? "/dev/null " : ""
+	let staged_flag = ( a:mode ==# 'staged' ) ? "--staged" : ""
 	let git_cmd=g:magit_git_cmd . " diff --no-ext-diff " . staged_flag .
 				\ " --no-color -p -U" . b:magit_diff_context .
 				\ " -- " . dev_null . " " . a:filename
 	silent let diff_list=magit#utils#systemlist(git_cmd)
-	if ( a:status != '?' && v:shell_error != 0 )
+	if ( a:status !=# '?' && v:shell_error != 0 )
 		echohl WarningMsg
 		echom "Git error: " . string(diff_list)
 		echom "Git cmd: " . git_cmd
@@ -134,7 +134,7 @@ function! magit#git#git_diff(filename, status, mode)
 		throw 'diff error'
 	endif
 	return [
-		\ ( diff_list[-1] =~ "^Binary files .* differ$" && len(diff_list) <= 4 )
+		\ ( diff_list[-1] =~# "^Binary files .* differ$" && len(diff_list) <= 4 )
 		\, diff_list ]
 endfunction
 
@@ -142,8 +142,8 @@ endfunction
 " untracked content
 " param[in] submodule: submodule path
 " param[in] check_level: can be modified or untracked
-function! magit#git#sub_check(submodule, check_level)
-	let ignore_flag = ( a:check_level == 'modified' ) ?
+function! magit#git#sub_check(submodule, check_level) abort
+	let ignore_flag = ( a:check_level ==# 'modified' ) ?
 				\ '--ignore-submodules=untracked' : ''
 	let git_cmd=g:magit_git_cmd . " status --porcelain " . ignore_flag . " " . a:submodule
 	return ( !empty(magit#utils#systemlist(git_cmd)) )
@@ -154,13 +154,13 @@ endfunction
 " message is raised.
 " param[in] filemane: it must be quoted if it contains spaces
 " param[in] mode: can be staged or unstaged
-function! magit#git#git_sub_summary(filename, mode)
-	let staged_flag = ( a:mode == 'staged' ) ? " --cached " : " --files "
+function! magit#git#git_sub_summary(filename, mode) abort
+	let staged_flag = ( a:mode ==# 'staged' ) ? " --cached " : " --files "
 	let git_cmd=g:magit_git_cmd . " submodule summary " . staged_flag . " HEAD "
 				\ .a:filename
 	silent let diff_list=magit#utils#systemlist(git_cmd)
 	if ( empty(diff_list) )
-		if ( a:mode == 'unstaged' )
+		if ( a:mode ==# 'unstaged' )
 			if ( magit#git#sub_check(a:filename, 'modified') )
 				return "modified content"
 			endif
@@ -180,7 +180,7 @@ endfunction
 " nota: when git fail (due to misformated patch for example), an error
 " message is raised.
 " param[in] filemane: it must be quoted if it contains spaces
-function! magit#git#git_add(filename)
+function! magit#git#git_add(filename) abort
 	let git_cmd=g:magit_git_cmd . " add --no-ignore-removal -- " . a:filename
 	silent let git_result=magit#utils#system(git_cmd)
 	if ( v:shell_error != 0 )
@@ -196,7 +196,7 @@ endfunction
 " nota: when git fail (due to misformated patch for example), an error
 " message is raised.
 " param[in] filemane: it must be quoted if it contains spaces
-function! magit#git#git_checkout(filename)
+function! magit#git#git_checkout(filename) abort
 	let git_cmd=g:magit_git_cmd . " checkout -- " . a:filename
 	silent let git_result=magit#utils#system(git_cmd)
 	if ( v:shell_error != 0 )
@@ -212,7 +212,7 @@ endfunction
 " nota: when git fail (due to misformated patch for example), an error
 " message is raised.
 " param[in] filemane: it must be quoted if it contains spaces
-function! magit#git#git_reset(filename)
+function! magit#git#git_reset(filename) abort
 	let git_cmd=g:magit_git_cmd . " reset HEAD -- " . a:filename
 	silent let git_result=magit#utils#system(git_cmd)
 	if ( v:shell_error != 0 )
@@ -230,9 +230,9 @@ endfunction
 " param[in] selection: the text to stage. It must be a patch, i.e. a diff 
 " header plus one or more hunks
 " return: no
-function! magit#git#git_apply(header, selection)
+function! magit#git#git_apply(header, selection) abort
 	let selection = magit#utils#flatten(a:header + a:selection)
-	if ( selection[-1] !~ '^$' )
+	if ( selection[-1] !~# '^$' )
 		let selection += [ '' ]
 	endif
 	let git_cmd=g:magit_git_cmd . " apply --recount --no-index --cached -"
@@ -254,13 +254,13 @@ endfunction
 " param[in] selection: the text to stage. It must be a patch, i.e. a diff 
 " header plus one or more hunks
 " return: no
-function! magit#git#git_unapply(header, selection, mode)
+function! magit#git#git_unapply(header, selection, mode) abort
 	let cached_flag=''
-	if ( a:mode == 'staged' )
+	if ( a:mode ==# 'staged' )
 		let cached_flag=' --cached '
 	endif
 	let selection = magit#utils#flatten(a:header + a:selection)
-	if ( selection[-1] !~ '^$' )
+	if ( selection[-1] !~# '^$' )
 		let selection += [ '' ]
 	endif
 	silent let git_result=magit#utils#system(
@@ -276,6 +276,6 @@ function! magit#git#git_unapply(header, selection, mode)
 	endif
 endfunction
 
-function! magit#git#submodule_status()
+function! magit#git#submodule_status() abort
 	return system(g:magit_git_cmd . " submodule status")
 endfunction

--- a/autoload/magit/sign.vim
+++ b/autoload/magit/sign.vim
@@ -12,7 +12,7 @@ let s:dummy_sign_id = s:first_sign_id - 1
 " Remove-all-signs optimisation requires Vim 7.3.596+.
 let s:supports_star = v:version > 703 || (v:version == 703 && has("patch596"))
 
-function! magit#sign#remove_all(...)
+function! magit#sign#remove_all(...) abort
 	if ( a:0 == 1 )
 		let pattern = a:1
 	else
@@ -24,14 +24,14 @@ endfunction
 
 " magit#sign#remove_signs: unplace a list of signs
 " param[in] sign_ids: list of signs dict
-function! magit#sign#remove_signs(sign_ids)
+function! magit#sign#remove_signs(sign_ids) abort
     let bufnr = magit#utils#bufnr()
     for sign in values(a:sign_ids)
         execute "sign unplace" sign.id
     endfor
 endfunction
 
-function! magit#sign#add_sign(line, type, bufnr)
+function! magit#sign#add_sign(line, type, bufnr) abort
 	let id = <SID>get_next_sign_id()
 	execute ":sign place " . id .
 		\ " line=" . a:line . " name=" . s:magit_mark_signs[a:type] .
@@ -39,12 +39,12 @@ function! magit#sign#add_sign(line, type, bufnr)
 	return id
 endfunction
 
-function! magit#sign#remove_sign(id)
+function! magit#sign#remove_sign(id) abort
 	execute ":sign unplace " . a:id
 endfunction
 
 " s:get_next_sign_id: helper function to increment sign ids
-function! s:get_next_sign_id()
+function! s:get_next_sign_id() abort
 	let next_id = s:next_sign_id
 	let s:next_sign_id += 1
 	return next_id
@@ -55,7 +55,7 @@ endfunction
 " param[in] pattern: regex pattern to match
 " param[in] startline,endline: range of lines
 " FIXME: find since which version "sign place" is sorted
-function! magit#sign#find_signs(pattern, startline, endline)
+function! magit#sign#find_signs(pattern, startline, endline) abort
 	let bufnr = magit#utils#bufnr()
 	" <line_number (string)>: {'id': <id (number)>, 'name': <name (string)>}
 	let found_signs = {}
@@ -83,7 +83,7 @@ endfunction
 " magit#sign#find_stage_signs: helper function to get marked lines for stage
 " param[in] startline,endline: range of lines
 " return Dict of marked lines
-function! magit#sign#find_stage_signs(startline, endline)
+function! magit#sign#find_stage_signs(startline, endline) abort
 	return magit#sign#find_signs(s:magit_mark_signs.M, a:startline, a:endline)
 endfunction
 
@@ -91,7 +91,7 @@ endfunction
 let s:magit_mark_signs = {'M': 'MagitTBS', 'S': 'MagitBS', 'E': 'MagitBE'}
 
 " magit#sign#init: initializer function for signs
-function! magit#sign#init()
+function! magit#sign#init() abort
 	execute "sign define " . s:magit_mark_signs.M . " text=S> linehl=Visual"
 	execute "sign define " . s:magit_mark_signs.S
 	execute "sign define " . s:magit_mark_signs.E
@@ -101,7 +101,7 @@ endfunction
 " marked lines are unmarked, non marked are marked
 " param[in] type; type of sign to toggle (see s:magit_mark_signs)
 " param[in] startline,endline: range of lines
-function! magit#sign#toggle_signs(type, startline, endline)
+function! magit#sign#toggle_signs(type, startline, endline) abort
 	let bufnr = magit#utils#bufnr()
 	let current_signs = magit#sign#find_signs(s:magit_mark_signs[a:type], a:startline, a:endline)
 	let line = a:startline

--- a/autoload/magit/state.vim
+++ b/autoload/magit/state.vim
@@ -1,27 +1,27 @@
 " magit#state#is_file_visible: file getter function
 " return if file is visible
-function! magit#state#is_file_visible() dict
+function! magit#state#is_file_visible() dict abort
 	return self.visible
 endfunction
 
 " magit#state#set_file_visible: file setter function
 " param[in] val: visible state to set to file
-function! magit#state#set_file_visible(val) dict
+function! magit#state#set_file_visible(val) dict abort
 	let self.visible = a:val
 endfunction
 
 " magit#state#toggle_file_visible: file setter function, toggle file visible
 " state
-function! magit#state#toggle_file_visible() dict
+function! magit#state#toggle_file_visible() dict abort
 	let self.visible = ( self.visible == 0 ) ? 1 : 0
 endfunction
 
 " magit#state#init_file_visible: init file visible status, among several conditions
-function! magit#state#init_file_visible() dict
+function! magit#state#init_file_visible() dict abort
 	if ( !self.new )
 		return self.is_visible()
 	else
-		if ( self.status == 'M' || b:magit_default_show_all_files > 1 )
+		if ( self.status ==# 'M' || b:magit_default_show_all_files > 1 )
 			call self.set_visible(b:magit_default_show_all_files)
 		endif
 		return self.is_visible()
@@ -30,7 +30,7 @@ endfunction
 
 " magit#state#is_file_dir: file getter function
 " return 1 if current file is a directory, 0 otherwise
-function! magit#state#is_file_dir() dict
+function! magit#state#is_file_dir() dict abort
 	return self.dir != 0
 endfunction
 
@@ -38,9 +38,9 @@ endfunction
 " there are some conditions where files must be widely added (git add), not
 " 'diff applied' (git apply)
 " return 1 if file must 
-function! magit#state#must_be_added() dict
+function! magit#state#must_be_added() dict abort
 	return ( self.empty == 1 ||
-		\ self.symlink != '' ||
+		\ self.symlink !=# '' ||
 		\ self.dir != 0 ||
 		\ self.binary == 1 ||
 		\ self.submodule == 1 )
@@ -48,13 +48,13 @@ endfunction
 
 " magit#state#file_get_hunks: function accessor for hunks objects
 " return: List of List of hunks lines
-function! magit#state#file_get_hunks() dict
+function! magit#state#file_get_hunks() dict abort
 	return self.diff.hunks
 endfunction
 
 " magit#state#file_get_flat_hunks: function accessor for hunks lines
 " return: all hunks lines of a file, including hunk headers
-function! magit#state#file_get_flat_hunks() dict
+function! magit#state#file_get_flat_hunks() dict abort
 	let hunks = self.diff.hunks
 	let lines = []
 	for hunk in hunks
@@ -113,7 +113,7 @@ let s:file_template = {
 " param[in] create: boolean. If 1, non existing file in Dict will be created.
 " if 0, 'file_doesnt_exists' exception will be thrown
 " return: Dict of file
-function! magit#state#get_file(mode, filename, ...) dict
+function! magit#state#get_file(mode, filename, ...) dict abort
 	let file_exists = has_key(self.dict[a:mode], a:filename)
 	let create = ( a:0 == 1 ) ? a:1 : 0
 	if ( file_exists == 0 && create == 1 )
@@ -129,19 +129,19 @@ endfunction
 " param[in] mode: can be staged or unstaged
 " param[in] filename: header of filename to access
 " return: List of diff header lines
-function! magit#state#file_get_header() dict
+function! magit#state#file_get_header() dict abort
 	return self.diff.header
 endfunction
 
-function! magit#state#file_get_filename_header() dict
-	if ( self.status == 'L' )
+function! magit#state#file_get_filename_header() dict abort
+	if ( self.status ==# 'L' )
 		return g:magit_git_status_code.L . ': ' . self.filename . ' -> ' . self.symlink
 	else
 		return g:magit_git_status_code[self.status] . ': ' . self.filename
 	endif
 endfunction
 
-function! magit#state#check_max_lines(file) dict
+function! magit#state#check_max_lines(file) dict abort
 	let total_lines = self.nb_diff_lines + a:file.diff.len
 	if ( total_lines > g:magit_warning_max_lines && b:magit_warning_max_lines_answered == 0 )
 		echohl WarningMsg
@@ -163,7 +163,7 @@ endfunction
 " param[in] mode: can be staged or unstaged
 " param[in] status: one character status code of the file (AMDRCU?)
 " param[in] filename: filename
-function! magit#state#add_file(mode, status, filename, depth) dict
+function! magit#state#add_file(mode, status, filename, depth) dict abort
 	let file = self.get_file(a:mode, a:filename, 1)
 	let file.exists = 1
 
@@ -173,7 +173,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict
 	" discard previous diff
 	let file.diff = deepcopy(s:diff_template)
 
-	if ( a:status == '?' && getftype(a:filename) == 'link' )
+	if ( a:status ==# '?' && getftype(a:filename) ==# 'link' )
 		let file.status = 'L'
 		let file.symlink = resolve(a:filename)
 		let file.diff.hunks[0].header = 'New symbolic link file'
@@ -194,7 +194,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict
 		let file.diff.hunks[0].header = ''
 		let file.diff.hunks[0].lines = diff_list
 		let self.nb_diff_lines += file.diff.len
-	elseif ( a:status == '?' && isdirectory(a:filename) == 1 )
+	elseif ( a:status ==# '?' && isdirectory(a:filename) == 1 )
 		let file.status = 'N'
 		let file.dir = 1
 		if ( !file.is_visible() )
@@ -203,7 +203,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict
 		for subfile in magit#utils#ls_all(a:filename)
 			call self.add_file(a:mode, a:status, subfile, a:depth + 1)
 		endfor
-	elseif ( a:status == '?' && getfsize(a:filename) == 0 )
+	elseif ( a:status ==# '?' && getfsize(a:filename) == 0 )
 		let file.status = 'E'
 		let file.empty = 1
 		let file.diff.hunks[0].header = 'New empty file'
@@ -232,7 +232,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict
 			return
 		endif
 
-		while ( line < file.diff.len && diff_list[line] !~ "^@.*" )
+		while ( line < file.diff.len && diff_list[line] !~# "^@.*" )
 			call add(file.diff.header, diff_list[line])
 			let line += 1
 		endwhile
@@ -242,7 +242,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict
 			let hunk.header = diff_list[line]
 
 			for diff_line in diff_list[line+1 : -1]
-				if ( diff_line =~ "^@.*" )
+				if ( diff_line =~# "^@.*" )
 					let hunk = deepcopy(s:hunk_template)
 					call add(file.diff.hunks, hunk)
 					let hunk.header = diff_line
@@ -261,7 +261,7 @@ endfunction
 " committed, deleted, discarded), it is removed from g:mg_diff_dict
 " else, its diff is discarded and regenrated
 " what is resilient is its 'visible' parameter
-function! magit#state#update() dict
+function! magit#state#update() dict abort
 	let self.nb_diff_lines = 0
 	for diff_dict_mode in values(self.dict)
 		for file in values(diff_dict_mode)
@@ -282,7 +282,7 @@ function! magit#state#update() dict
 				let status=file_status[mode]
 
 				" untracked code apperas in staged column, we skip it
-				if ( status == ' ' || ( ( mode == 'staged' ) && status == '?' ) )
+				if ( status ==# ' ' || ( ( mode ==# 'staged' ) && status ==# '?' ) )
 					continue
 				endif
 				call self.add_file(mode, status, file_status.filename, 0)
@@ -305,7 +305,7 @@ endfunction
 " magit#state#set_files_visible: global dict setter function
 " update all files visible state
 " param[in] is_visible: boolean value to set to files
-function! magit#state#set_files_visible(is_visible) dict
+function! magit#state#set_files_visible(is_visible) dict abort
 	for diff_dict_mode in values(self.dict)
 		for file in values(diff_dict_mode)
 			call file.set_visible(a:is_visible)
@@ -316,7 +316,7 @@ endfunction
 " magit#state#get_files: global dict file objects getter function
 " param[in] mode: mode to select, can be 'staged' or 'unstaged'
 " return list of file objects belonging to mode
-function! magit#state#get_files(mode) dict
+function! magit#state#get_files(mode) dict abort
 	return self.dict[a:mode]
 endfunction
 
@@ -324,12 +324,12 @@ endfunction
 " param[in] mode: mode to select, can be 'staged' or 'unstaged'
 " return ordered list of filename strings belonging to mode, modified files
 " first
-function! magit#state#get_filenames(mode) dict
+function! magit#state#get_filenames(mode) dict abort
 	let modified = []
 	let others = []
 	for filename in sort(keys(self.dict[a:mode]))
 		let file = self.get_file(a:mode, filename)
-		if ( file.status == 'M' )
+		if ( file.status ==# 'M' )
 			call add(modified, filename)
 		else
 			call add(others, filename)

--- a/autoload/magit/state.vim
+++ b/autoload/magit/state.vim
@@ -274,7 +274,7 @@ function! magit#state#update() dict
 
 	let dir = getcwd()
 	try
-		call magit#utils#lcd(magit#git#top_dir())
+		call magit#utils#chdir(magit#git#top_dir())
 		call magit#utils#refresh_submodule_list()
 		for [mode, diff_dict_mode] in items(self.dict)
 			let status_list = magit#git#get_status()
@@ -289,7 +289,7 @@ function! magit#state#update() dict
 			endfor
 		endfor
 	finally
-		call magit#utils#lcd(dir)
+		call magit#utils#chdir(dir)
 	endtry
 
 	" remove files that have changed their mode or been committed/deleted/discarded...

--- a/autoload/magit/state.vim
+++ b/autoload/magit/state.vim
@@ -38,10 +38,9 @@ endfunction
 " there are some conditions where files must be widely added (git add), not
 " 'diff applied' (git apply)
 " return 1 if file must 
-function! magit#state#must_be_added() dict
 function! magit#state#must_be_added() dict abort
 	return ( self.empty == 1 ||
-		\ self.symlink != '' ||
+		\ self.symlink !=# '' ||
 		\ self.dir != 0 ||
 		\ self.binary == 1 ||
 		\ self.submodule == 1 )
@@ -130,21 +129,18 @@ endfunction
 " param[in] mode: can be staged or unstaged
 " param[in] filename: header of filename to access
 " return: List of diff header lines
-function! magit#state#file_get_header() dict
 function! magit#state#file_get_header() dict abort
 	return self.diff.header
 endfunction
 
-function! magit#state#file_get_filename_header() dict
-	if ( self.status == 'L' )
 function! magit#state#file_get_filename_header() dict abort
+	if ( self.status ==# 'L' )
 		return g:magit_git_status_code.L . ': ' . self.filename . ' -> ' . self.symlink
 	else
 		return g:magit_git_status_code[self.status] . ': ' . self.filename
 	endif
 endfunction
 
-function! magit#state#check_max_lines(file) dict
 function! magit#state#check_max_lines(file) dict abort
 	let total_lines = self.nb_diff_lines + a:file.diff.len
 	if ( total_lines > g:magit_warning_max_lines && b:magit_warning_max_lines_answered == 0 )
@@ -177,7 +173,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict abort
 	" discard previous diff
 	let file.diff = deepcopy(s:diff_template)
 
-	if ( a:status == '?' && getftype(a:filename) == 'link' )
+	if ( a:status ==# '?' && getftype(a:filename) ==# 'link' )
 		let file.status = 'L'
 		let file.symlink = resolve(a:filename)
 		let file.diff.hunks[0].header = 'New symbolic link file'
@@ -198,7 +194,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict abort
 		let file.diff.hunks[0].header = ''
 		let file.diff.hunks[0].lines = diff_list
 		let self.nb_diff_lines += file.diff.len
-	elseif ( a:status == '?' && isdirectory(a:filename) == 1 )
+	elseif ( a:status ==# '?' && isdirectory(a:filename) == 1 )
 		let file.status = 'N'
 		let file.dir = 1
 		if ( !file.is_visible() )
@@ -207,7 +203,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict abort
 		for subfile in magit#utils#ls_all(a:filename)
 			call self.add_file(a:mode, a:status, subfile, a:depth + 1)
 		endfor
-	elseif ( a:status == '?' && getfsize(a:filename) == 0 )
+	elseif ( a:status ==# '?' && getfsize(a:filename) == 0 )
 		let file.status = 'E'
 		let file.empty = 1
 		let file.diff.hunks[0].header = 'New empty file'
@@ -236,7 +232,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict abort
 			return
 		endif
 
-		while ( line < file.diff.len && diff_list[line] !~ "^@.*" )
+		while ( line < file.diff.len && diff_list[line] !~# "^@.*" )
 			call add(file.diff.header, diff_list[line])
 			let line += 1
 		endwhile
@@ -246,7 +242,7 @@ function! magit#state#add_file(mode, status, filename, depth) dict abort
 			let hunk.header = diff_list[line]
 
 			for diff_line in diff_list[line+1 : -1]
-				if ( diff_line =~ "^@.*" )
+				if ( diff_line =~# "^@.*" )
 					let hunk = deepcopy(s:hunk_template)
 					call add(file.diff.hunks, hunk)
 					let hunk.header = diff_line
@@ -286,7 +282,7 @@ function! magit#state#update() dict abort
 				let status=file_status[mode]
 
 				" untracked code apperas in staged column, we skip it
-				if ( status == ' ' || ( ( mode == 'staged' ) && status == '?' ) )
+				if ( status ==# ' ' || ( ( mode ==# 'staged' ) && status ==# '?' ) )
 					continue
 				endif
 				call self.add_file(mode, status, file_status.filename, 0)
@@ -328,13 +324,12 @@ endfunction
 " param[in] mode: mode to select, can be 'staged' or 'unstaged'
 " return ordered list of filename strings belonging to mode, modified files
 " first
-function! magit#state#get_filenames(mode) dict
 function! magit#state#get_filenames(mode) dict abort
 	let modified = []
 	let others = []
 	for filename in sort(keys(self.dict[a:mode]))
 		let file = self.get_file(a:mode, filename)
-		if ( file.status == 'M' )
+		if ( file.status ==# 'M' )
 			call add(modified, filename)
 		else
 			call add(others, filename)

--- a/autoload/magit/state.vim
+++ b/autoload/magit/state.vim
@@ -1,27 +1,27 @@
 " magit#state#is_file_visible: file getter function
 " return if file is visible
-function! magit#state#is_file_visible() dict
+function! magit#state#is_file_visible() dict abort
 	return self.visible
 endfunction
 
 " magit#state#set_file_visible: file setter function
 " param[in] val: visible state to set to file
-function! magit#state#set_file_visible(val) dict
+function! magit#state#set_file_visible(val) dict abort
 	let self.visible = a:val
 endfunction
 
 " magit#state#toggle_file_visible: file setter function, toggle file visible
 " state
-function! magit#state#toggle_file_visible() dict
+function! magit#state#toggle_file_visible() dict abort
 	let self.visible = ( self.visible == 0 ) ? 1 : 0
 endfunction
 
 " magit#state#init_file_visible: init file visible status, among several conditions
-function! magit#state#init_file_visible() dict
+function! magit#state#init_file_visible() dict abort
 	if ( !self.new )
 		return self.is_visible()
 	else
-		if ( self.status == 'M' || b:magit_default_show_all_files > 1 )
+		if ( self.status ==# 'M' || b:magit_default_show_all_files > 1 )
 			call self.set_visible(b:magit_default_show_all_files)
 		endif
 		return self.is_visible()
@@ -30,7 +30,7 @@ endfunction
 
 " magit#state#is_file_dir: file getter function
 " return 1 if current file is a directory, 0 otherwise
-function! magit#state#is_file_dir() dict
+function! magit#state#is_file_dir() dict abort
 	return self.dir != 0
 endfunction
 
@@ -39,6 +39,7 @@ endfunction
 " 'diff applied' (git apply)
 " return 1 if file must 
 function! magit#state#must_be_added() dict
+function! magit#state#must_be_added() dict abort
 	return ( self.empty == 1 ||
 		\ self.symlink != '' ||
 		\ self.dir != 0 ||
@@ -48,13 +49,13 @@ endfunction
 
 " magit#state#file_get_hunks: function accessor for hunks objects
 " return: List of List of hunks lines
-function! magit#state#file_get_hunks() dict
+function! magit#state#file_get_hunks() dict abort
 	return self.diff.hunks
 endfunction
 
 " magit#state#file_get_flat_hunks: function accessor for hunks lines
 " return: all hunks lines of a file, including hunk headers
-function! magit#state#file_get_flat_hunks() dict
+function! magit#state#file_get_flat_hunks() dict abort
 	let hunks = self.diff.hunks
 	let lines = []
 	for hunk in hunks
@@ -113,7 +114,7 @@ let s:file_template = {
 " param[in] create: boolean. If 1, non existing file in Dict will be created.
 " if 0, 'file_doesnt_exists' exception will be thrown
 " return: Dict of file
-function! magit#state#get_file(mode, filename, ...) dict
+function! magit#state#get_file(mode, filename, ...) dict abort
 	let file_exists = has_key(self.dict[a:mode], a:filename)
 	let create = ( a:0 == 1 ) ? a:1 : 0
 	if ( file_exists == 0 && create == 1 )
@@ -130,11 +131,13 @@ endfunction
 " param[in] filename: header of filename to access
 " return: List of diff header lines
 function! magit#state#file_get_header() dict
+function! magit#state#file_get_header() dict abort
 	return self.diff.header
 endfunction
 
 function! magit#state#file_get_filename_header() dict
 	if ( self.status == 'L' )
+function! magit#state#file_get_filename_header() dict abort
 		return g:magit_git_status_code.L . ': ' . self.filename . ' -> ' . self.symlink
 	else
 		return g:magit_git_status_code[self.status] . ': ' . self.filename
@@ -142,6 +145,7 @@ function! magit#state#file_get_filename_header() dict
 endfunction
 
 function! magit#state#check_max_lines(file) dict
+function! magit#state#check_max_lines(file) dict abort
 	let total_lines = self.nb_diff_lines + a:file.diff.len
 	if ( total_lines > g:magit_warning_max_lines && b:magit_warning_max_lines_answered == 0 )
 		echohl WarningMsg
@@ -163,7 +167,7 @@ endfunction
 " param[in] mode: can be staged or unstaged
 " param[in] status: one character status code of the file (AMDRCU?)
 " param[in] filename: filename
-function! magit#state#add_file(mode, status, filename, depth) dict
+function! magit#state#add_file(mode, status, filename, depth) dict abort
 	let file = self.get_file(a:mode, a:filename, 1)
 	let file.exists = 1
 
@@ -261,7 +265,7 @@ endfunction
 " committed, deleted, discarded), it is removed from g:mg_diff_dict
 " else, its diff is discarded and regenrated
 " what is resilient is its 'visible' parameter
-function! magit#state#update() dict
+function! magit#state#update() dict abort
 	let self.nb_diff_lines = 0
 	for diff_dict_mode in values(self.dict)
 		for file in values(diff_dict_mode)
@@ -305,7 +309,7 @@ endfunction
 " magit#state#set_files_visible: global dict setter function
 " update all files visible state
 " param[in] is_visible: boolean value to set to files
-function! magit#state#set_files_visible(is_visible) dict
+function! magit#state#set_files_visible(is_visible) dict abort
 	for diff_dict_mode in values(self.dict)
 		for file in values(diff_dict_mode)
 			call file.set_visible(a:is_visible)
@@ -316,7 +320,7 @@ endfunction
 " magit#state#get_files: global dict file objects getter function
 " param[in] mode: mode to select, can be 'staged' or 'unstaged'
 " return list of file objects belonging to mode
-function! magit#state#get_files(mode) dict
+function! magit#state#get_files(mode) dict abort
 	return self.dict[a:mode]
 endfunction
 
@@ -325,6 +329,7 @@ endfunction
 " return ordered list of filename strings belonging to mode, modified files
 " first
 function! magit#state#get_filenames(mode) dict
+function! magit#state#get_filenames(mode) dict abort
 	let modified = []
 	let others = []
 	for filename in sort(keys(self.dict[a:mode]))

--- a/autoload/magit/state.vim
+++ b/autoload/magit/state.vim
@@ -94,6 +94,7 @@ let s:file_template = {
 \	'submodule': 0,
 \	'symlink': '',
 \	'diff': s:diff_template,
+\	'line_pos': 0,
 \	'is_dir': function("magit#state#is_file_dir"),
 \	'is_visible': function("magit#state#is_file_visible"),
 \	'set_visible': function("magit#state#set_file_visible"),

--- a/autoload/magit/utils.vim
+++ b/autoload/magit/utils.vim
@@ -1,7 +1,7 @@
 
 " magit#utils#ls_all: list all files (including hidden ones) in a given path
 " return : list of filenames
-function! magit#utils#ls_all(path)
+function! magit#utils#ls_all(path) abort
 	return split(globpath(a:path, '.[^.]*', 1) . "\n" .
 				\ globpath(a:path, '*', 1), '\n')
 endfunction
@@ -9,20 +9,20 @@ endfunction
 let s:submodule_list = []
 " magit#utils#refresh_submodule_list: this function refresh the List s:submodule_list
 " magit#utils#is_submodule() is using s:submodule_list
-function! magit#utils#refresh_submodule_list()
+function! magit#utils#refresh_submodule_list() abort
 	let s:submodule_list = map(split(magit#git#submodule_status(), "\n"), 'split(v:val)[1]')
 endfunction
 
 " magit#utils#is_submodule search if dirname is in s:submodule_list 
 " param[in] dirname: must end with /
 " INFO: must be called from top work tree
-function! magit#utils#is_submodule(dirname)
+function! magit#utils#is_submodule(dirname) abort
 	return ( index(s:submodule_list, a:dirname) != -1 )
 endfunction
 
 " magit#utils#chdir will change the directory respecting
 " local/tab-local/global directory settings.
-function! magit#utils#chdir(dir)
+function! magit#utils#chdir(dir) abort
   " This is a dirty hack to fix tcd breakages on neovim.
   " Future work should be based on nvim API.
   if exists(':tcd')
@@ -40,7 +40,7 @@ endfunction
 " with a change. The hack is the line
 " exe "normal a \<BS>\<Esc>"
 " We move on first line to make this trick where it should be no folding
-function! magit#utils#clear_undo()
+function! magit#utils#clear_undo() abort
 	let old_undolevels = &l:undolevels
 	let cur_pos = line('.')
 	setlocal undolevels=-1
@@ -57,7 +57,7 @@ endfunction
 " pwd at the end of function
 " param[in] ...: command + optional args
 " return: command output as a string
-function! magit#utils#system(...)
+function! magit#utils#system(...) abort
 	let dir = getcwd()
 	try
 		call magit#utils#chdir(magit#git#top_dir())
@@ -90,7 +90,7 @@ endfunction
 " pwd at the end of function
 " param[in] ...: command + optional args to execute, args can be List or String
 " return: command output as a list
-function! magit#utils#systemlist(...)
+function! magit#utils#systemlist(...) abort
 	let dir = getcwd()
 	try
 		call magit#utils#chdir(magit#git#top_dir())
@@ -108,7 +108,7 @@ endfunction
 " magit#utils#underline: helper function to underline a string
 " param[in] title: string to underline
 " return a string composed of strlen(title) '='
-function! magit#utils#underline(title)
+function! magit#utils#underline(title) abort
 	return substitute(a:title, ".", "=", "g")
 endfunction
 
@@ -116,7 +116,7 @@ endfunction
 " WARNING: it only works with monoline string
 " param[in] string: string to strip
 " return: stripped string
-function! magit#utils#strip(string)
+function! magit#utils#strip(string) abort
 	return substitute(a:string, '^\s*\(.\{-}\)\s*\n\=$', '\1', '')
 endfunction
 
@@ -125,6 +125,7 @@ endfunction
 " param[in] array: array to strop
 " return: stripped array
 function! magit#utils#strip_array(array)
+function! magit#utils#strip_array(array) abort
 	let array_len = len(a:array)
 	let start = 0
 	while ( start < array_len && a:array[start] == '' )
@@ -140,19 +141,19 @@ endfunction
 " magit#utils#join_list: helper function to concatente a list of strings with newlines
 " param[in] list: List to concat
 " return: concatenated list
-function! magit#utils#join_list(list)
+function! magit#utils#join_list(list) abort
 	return join(a:list, "\n") . "\n"
 endfunction
 
 " magit#utils#add_quotes: helper function to protect filename with quotes
 " return quoted filename
-function! magit#utils#add_quotes(filename)
+function! magit#utils#add_quotes(filename) abort
 	return '"' . a:filename . '"'
 endfunction
 
 " magit#utils#remove_quotes: helper function to remove quotes aroudn filename
 " return unquoted filename
-function! magit#utils#remove_quotes(filename)
+function! magit#utils#remove_quotes(filename) abort
 	let ret=matchlist(a:filename, '"\([^"]*\)"')
 	if ( empty(ret) )
 		throw 'no quotes found: ' . a:filename
@@ -165,7 +166,7 @@ endfunction
 " https://gist.github.com/dahu/3322468
 " param[in] list: a List, can be nested or not
 " return: one dimensional list
-function! magit#utils#flatten(list)
+function! magit#utils#flatten(list) abort
 	let val = []
 	for elem in a:list
 		if type(elem) == type([])
@@ -182,7 +183,7 @@ endfunction
 " Version working with file *possibly* containing trailing newline
 " param[in] file: filename to append
 " param[in] lines: List of lines to append
-function! magit#utils#append_file(file, lines)
+function! magit#utils#append_file(file, lines) abort
 	let fcontents=[]
 	if ( filereadable(a:file) )
 		let fcontents=readfile(a:file, 'b')
@@ -197,13 +198,13 @@ endfunction
 let s:bufnr = 0
 " magit#utils#setbufnr: function to set current magit buffer id
 " param[in] bufnr: current magit buffer id
-function! magit#utils#setbufnr(bufnr)
+function! magit#utils#setbufnr(bufnr) abort
 	let s:bufnr = a:bufnr
 endfunction
 
 " magit#utils#bufnr: function to get current magit buffer id
 " return: current magit buffer id
-function! magit#utils#bufnr()
+function! magit#utils#bufnr() abort
 	return s:bufnr
 endfunction
 
@@ -213,7 +214,7 @@ endfunction
 " calling this function
 " param[in] filename: filename to search
 " return: window id, 0 if not found
-function! magit#utils#search_buffer_in_windows(filename)
+function! magit#utils#search_buffer_in_windows(filename) abort
 	let cur_win = winnr()
 	let last_win = winnr('#')
 	let files={}
@@ -225,6 +226,7 @@ function! magit#utils#search_buffer_in_windows(filename)
 endfunction
 
 function! magit#utils#start_profile(...)
+function! magit#utils#start_profile(...) abort
 	let prof_file = ( a:0 == 1 ) ? a:1 : "/tmp/vimagit.log"
 	execute "profile start " . prof_file . " | profile pause"
 	profile! file */plugin/magit.vim

--- a/autoload/magit/utils.vim
+++ b/autoload/magit/utils.vim
@@ -25,7 +25,7 @@ endfunction
 let s:magit_cd_cmd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
 " magit#utils#lcd: helper function to lcd. use cd if lcd doesn't exists
 function! magit#utils#lcd(dir)
-	execute s:magit_cd_cmd . a:dir
+	execute s:magit_cd_cmd . fnameescape(a:dir)
 endfunction
 
 " magit#utils#clear_undo: this function clear local undo history.
@@ -55,7 +55,7 @@ endfunction
 function! magit#utils#system(...)
 	let dir = getcwd()
 	try
-		execute s:magit_cd_cmd . magit#git#top_dir()
+		call magit#utils#lcd(magit#git#top_dir())
 		" List as system() input is since v7.4.247, it is safe to check
 		" systemlist, which is sine v7.4.248
 		if exists('*systemlist')
@@ -75,7 +75,7 @@ function! magit#utils#system(...)
 			endif
 		endif
 	finally
-		execute s:magit_cd_cmd . dir
+		call magit#utils#lcd(dir)
 	endtry
 endfunction
 
@@ -88,7 +88,7 @@ endfunction
 function! magit#utils#systemlist(...)
 	let dir = getcwd()
 	try
-		execute s:magit_cd_cmd . magit#git#top_dir()
+		call magit#utils#lcd(magit#git#top_dir())
 		" systemlist since v7.4.248
 		if exists('*systemlist')
 			return call('systemlist', a:000)
@@ -96,7 +96,7 @@ function! magit#utils#systemlist(...)
 			return split(call('magit#utils#system', a:000), '\n')
 		endif
 	finally
-		execute s:magit_cd_cmd . dir
+		call magit#utils#lcd(dir)
 	endtry
 endfunction
 

--- a/autoload/magit/utils.vim
+++ b/autoload/magit/utils.vim
@@ -1,7 +1,7 @@
 
 " magit#utils#ls_all: list all files (including hidden ones) in a given path
 " return : list of filenames
-function! magit#utils#ls_all(path)
+function! magit#utils#ls_all(path) abort
 	return split(globpath(a:path, '.[^.]*', 1) . "\n" .
 				\ globpath(a:path, '*', 1), '\n')
 endfunction
@@ -9,20 +9,20 @@ endfunction
 let s:submodule_list = []
 " magit#utils#refresh_submodule_list: this function refresh the List s:submodule_list
 " magit#utils#is_submodule() is using s:submodule_list
-function! magit#utils#refresh_submodule_list()
+function! magit#utils#refresh_submodule_list() abort
 	let s:submodule_list = map(split(magit#git#submodule_status(), "\n"), 'split(v:val)[1]')
 endfunction
 
 " magit#utils#is_submodule search if dirname is in s:submodule_list 
 " param[in] dirname: must end with /
 " INFO: must be called from top work tree
-function! magit#utils#is_submodule(dirname)
+function! magit#utils#is_submodule(dirname) abort
 	return ( index(s:submodule_list, a:dirname) != -1 )
 endfunction
 
 " magit#utils#chdir will change the directory respecting
 " local/tab-local/global directory settings.
-function! magit#utils#chdir(dir)
+function! magit#utils#chdir(dir) abort
   " This is a dirty hack to fix tcd breakages on neovim.
   " Future work should be based on nvim API.
   if exists(':tcd')
@@ -40,7 +40,7 @@ endfunction
 " with a change. The hack is the line
 " exe "normal a \<BS>\<Esc>"
 " We move on first line to make this trick where it should be no folding
-function! magit#utils#clear_undo()
+function! magit#utils#clear_undo() abort
 	let old_undolevels = &l:undolevels
 	let cur_pos = line('.')
 	setlocal undolevels=-1
@@ -57,7 +57,7 @@ endfunction
 " pwd at the end of function
 " param[in] ...: command + optional args
 " return: command output as a string
-function! magit#utils#system(...)
+function! magit#utils#system(...) abort
 	let dir = getcwd()
 	try
 		call magit#utils#chdir(magit#git#top_dir())
@@ -90,7 +90,7 @@ endfunction
 " pwd at the end of function
 " param[in] ...: command + optional args to execute, args can be List or String
 " return: command output as a list
-function! magit#utils#systemlist(...)
+function! magit#utils#systemlist(...) abort
 	let dir = getcwd()
 	try
 		call magit#utils#chdir(magit#git#top_dir())
@@ -108,7 +108,7 @@ endfunction
 " magit#utils#underline: helper function to underline a string
 " param[in] title: string to underline
 " return a string composed of strlen(title) '='
-function! magit#utils#underline(title)
+function! magit#utils#underline(title) abort
 	return substitute(a:title, ".", "=", "g")
 endfunction
 
@@ -116,7 +116,7 @@ endfunction
 " WARNING: it only works with monoline string
 " param[in] string: string to strip
 " return: stripped string
-function! magit#utils#strip(string)
+function! magit#utils#strip(string) abort
 	return substitute(a:string, '^\s*\(.\{-}\)\s*\n\=$', '\1', '')
 endfunction
 
@@ -124,14 +124,14 @@ endfunction
 " on both sides)
 " param[in] array: array to strop
 " return: stripped array
-function! magit#utils#strip_array(array)
+function! magit#utils#strip_array(array) abort
 	let array_len = len(a:array)
 	let start = 0
-	while ( start < array_len && a:array[start] == '' )
+	while ( start < array_len && a:array[start] ==# '' )
 		let start += 1
 	endwhile
 	let end = array_len - 1
-	while ( end >= 0 && a:array[end] == '' )
+	while ( end >= 0 && a:array[end] ==# '' )
 		let end -= 1
 	endwhile
 	return a:array[ start : end ]
@@ -140,19 +140,19 @@ endfunction
 " magit#utils#join_list: helper function to concatente a list of strings with newlines
 " param[in] list: List to concat
 " return: concatenated list
-function! magit#utils#join_list(list)
+function! magit#utils#join_list(list) abort
 	return join(a:list, "\n") . "\n"
 endfunction
 
 " magit#utils#add_quotes: helper function to protect filename with quotes
 " return quoted filename
-function! magit#utils#add_quotes(filename)
+function! magit#utils#add_quotes(filename) abort
 	return '"' . a:filename . '"'
 endfunction
 
 " magit#utils#remove_quotes: helper function to remove quotes aroudn filename
 " return unquoted filename
-function! magit#utils#remove_quotes(filename)
+function! magit#utils#remove_quotes(filename) abort
 	let ret=matchlist(a:filename, '"\([^"]*\)"')
 	if ( empty(ret) )
 		throw 'no quotes found: ' . a:filename
@@ -165,7 +165,7 @@ endfunction
 " https://gist.github.com/dahu/3322468
 " param[in] list: a List, can be nested or not
 " return: one dimensional list
-function! magit#utils#flatten(list)
+function! magit#utils#flatten(list) abort
 	let val = []
 	for elem in a:list
 		if type(elem) == type([])
@@ -182,7 +182,7 @@ endfunction
 " Version working with file *possibly* containing trailing newline
 " param[in] file: filename to append
 " param[in] lines: List of lines to append
-function! magit#utils#append_file(file, lines)
+function! magit#utils#append_file(file, lines) abort
 	let fcontents=[]
 	if ( filereadable(a:file) )
 		let fcontents=readfile(a:file, 'b')
@@ -197,13 +197,13 @@ endfunction
 let s:bufnr = 0
 " magit#utils#setbufnr: function to set current magit buffer id
 " param[in] bufnr: current magit buffer id
-function! magit#utils#setbufnr(bufnr)
+function! magit#utils#setbufnr(bufnr) abort
 	let s:bufnr = a:bufnr
 endfunction
 
 " magit#utils#bufnr: function to get current magit buffer id
 " return: current magit buffer id
-function! magit#utils#bufnr()
+function! magit#utils#bufnr() abort
 	return s:bufnr
 endfunction
 
@@ -213,7 +213,7 @@ endfunction
 " calling this function
 " param[in] filename: filename to search
 " return: window id, 0 if not found
-function! magit#utils#search_buffer_in_windows(filename)
+function! magit#utils#search_buffer_in_windows(filename) abort
 	let cur_win = winnr()
 	let last_win = winnr('#')
 	let files={}
@@ -224,7 +224,7 @@ function! magit#utils#search_buffer_in_windows(filename)
 				\files[buffer_name(a:filename)] : 0
 endfunction
 
-function! magit#utils#start_profile(...)
+function! magit#utils#start_profile(...) abort
 	let prof_file = ( a:0 == 1 ) ? a:1 : "/tmp/vimagit.log"
 	execute "profile start " . prof_file . " | profile pause"
 	profile! file */plugin/magit.vim

--- a/autoload/magit/utils.vim
+++ b/autoload/magit/utils.vim
@@ -124,15 +124,14 @@ endfunction
 " on both sides)
 " param[in] array: array to strop
 " return: stripped array
-function! magit#utils#strip_array(array)
 function! magit#utils#strip_array(array) abort
 	let array_len = len(a:array)
 	let start = 0
-	while ( start < array_len && a:array[start] == '' )
+	while ( start < array_len && a:array[start] ==# '' )
 		let start += 1
 	endwhile
 	let end = array_len - 1
-	while ( end >= 0 && a:array[end] == '' )
+	while ( end >= 0 && a:array[end] ==# '' )
 		let end -= 1
 	endwhile
 	return a:array[ start : end ]
@@ -225,7 +224,6 @@ function! magit#utils#search_buffer_in_windows(filename) abort
 				\files[buffer_name(a:filename)] : 0
 endfunction
 
-function! magit#utils#start_profile(...)
 function! magit#utils#start_profile(...) abort
 	let prof_file = ( a:0 == 1 ) ? a:1 : "/tmp/vimagit.log"
 	execute "profile start " . prof_file . " | profile pause"

--- a/doc/vimagit.txt
+++ b/doc/vimagit.txt
@@ -239,7 +239,7 @@ Following mappings are set locally, for magit buffer only, in normal mode.
             If in commit section, create the commit with the commit message and
             all staged changes.
 
-                                    *vimagit-:w*      *magit#commit_command('CC')*
+                                    *vimagit-:w*
   :w :x :wq ZZ
             If in commit section, create the commit with the commit message and
             all staged changes.

--- a/doc/vimagit.txt
+++ b/doc/vimagit.txt
@@ -65,10 +65,11 @@ If you move the cursor to the file header and press S, the whole file is
 staged.
 
 > CC
-Once you have stage all the required changes, press CC. A new section "Commit
-message" appears and cursor move to it. Type your commit message, in Insert
-mode this time. Once it's done, go back in Normal mode, and press CC: you
-created your first commit with vimagit!
+Once you have stage all the required changes, type CC. A new section "Commit
+message" appears and cursor move to it. Type your commit message, in Insert mode
+this time. Once it's done, write your commit message with :w (or :x, :wq, ZZ).
+
+Voila! you created your first commit with vimagit!
 
 ===============================================================================
 4. USAGE                                                         *vimagit-usage*
@@ -232,9 +233,14 @@ Following mappings are set locally, for magit buffer only, in normal mode.
                                     *vimagit-CC*      *magit#commit_command('CC')*
                                     *vimagit-g:magit_commit_mapping*
   CC        If not in commit section, set commit mode to "New commit" and show 
-           "Commit message" section with brand new commit message.
-            If in commit section, commit the all staged changes in commit mode
-            previously set.
+            "Commit message" section with brand new commit message.
+            If in commit section, create the commit with the commit message and
+            all staged changes.
+
+                                    *vimagit-:w*      *magit#commit_command('CC')*
+  :w :x :wq ZZ
+            If in commit section, create the commit with the commit message and
+            all staged changes.
 
                                     *vimagit-CA*      *magit#commit_command('CA')*
                                     *vimagit-g:magit_commit_amend_mapping*

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -272,10 +272,10 @@ function! s:mg_get_commit_section()
 		" refresh the COMMIT_EDITMSG file
 		if ( b:magit_current_commit_mode == 'CC' )
 			silent! call magit#utils#system("GIT_EDITOR=/bin/false " .
-						\ g:magit_git_cmd . " commit -e 2> /dev/null")
+						\ g:magit_git_cmd . " -c commit.verbose=no commit -e 2> /dev/null")
 		elseif ( b:magit_current_commit_mode == 'CA' )
 			silent! call magit#utils#system("GIT_EDITOR=/bin/false " .
-						\ g:magit_git_cmd . " commit --amend -e 2> /dev/null")
+						\ g:magit_git_cmd . " -c commit.verbose=no commit --amend -e 2> /dev/null")
 		endif
 		if ( filereadable(git_dir . 'COMMIT_EDITMSG') )
 			let comment_char=magit#git#get_config("core.commentChar", '#')

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -15,7 +15,8 @@ let g:vimagit_version = [1, 6, 0]
 
 " source common file. variables in common file are shared with plugin and
 " syntax files
-execute 'source ' . resolve(expand('<sfile>:p:h')) . '/../common/magit_common.vim'
+let g:vimagit_path = fnameescape(resolve(expand('<sfile>:p:h')))
+execute 'source ' . g:vimagit_path . '/../common/magit_common.vim'
 
 " these mappings are broadly applied, for all vim buffers
 let g:magit_show_magit_mapping     = get(g:, 'magit_show_magit_mapping',        '<leader>M' )

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -55,18 +55,22 @@ let g:magit_default_fold_level     = get(g:, 'magit_default_fold_level',        
 let g:magit_default_sections       = get(g:, 'magit_default_sections',          ['info', 'global_help', 'commit', 'staged', 'unstaged'])
 let g:magit_discard_untracked_do_delete = get(g:, 'magit_discard_untracked_do_delete',        0)
 
-let g:magit_refresh_gitgutter      = get(g:, 'magit_refresh_gitgutter',         1)
+let g:magit_refresh_gutter         = get(g:, 'magit_refresh_gutter'   ,         1)
+" Should deprecate the following
+let g:magit_refresh_gitgutter      = get(g:, 'magit_refresh_gitgutter',         0)
 let g:magit_warning_max_lines      = get(g:, 'magit_warning_max_lines',         10000)
 
 let g:magit_git_cmd                = get(g:, 'magit_git_cmd'          ,         "git")
 
 execute "nnoremap <silent> " . g:magit_show_magit_mapping . " :call magit#show_magit('v')<cr>"
 
-if ( g:magit_refresh_gitgutter == 1 )
-	autocmd User VimagitUpdateFile
-			\ if ( exists("*gitgutter#process_buffer") ) |
-			\ 	call gitgutter#process_buffer(bufnr(g:magit_last_updated_buffer), 0) |
-			\ endif
+if (g:magit_refresh_gutter == 1 || g:magit_refresh_gitgutter == 1)
+  autocmd User VimagitUpdateFile
+    \ if ( exists("*gitgutter#process_buffer") ) |
+    \   call gitgutter#process_buffer(bufnr(g:magit_last_updated_buffer), 0) |
+    \ elseif ( exists("*sy#util#refresh_windows") ) |
+    \   call sy#util#refresh_windows() |
+    \ endif
 endif
 " }}}
 

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -170,7 +170,7 @@ function! s:mg_get_info()
 	silent put =g:magit_section_info.cur_repo    . ': ' . magit#git#top_dir()
 	silent put =g:magit_section_info.cur_branch  . ':     ' . branch
 	silent put =g:magit_section_info.cur_commit  . ':        ' . commit
-	if ( b:magit_current_commit_mode != '' )
+	if ( b:magit_current_commit_mode !=# '' )
 	silent put =g:magit_section_info.commit_mode . ':        '
 				\ . g:magit_commit_mode[b:magit_current_commit_mode]
 	endif
@@ -212,7 +212,7 @@ function! s:mg_display_files(mode, curdir, depth)
 		endif
 		let hunks = file.get_hunks()
 		for hunk in hunks
-			if ( hunk.header != '' )
+			if ( hunk.header !=# '' )
 				silent put =hunk.header
 			endif
 			if ( !empty(hunk.lines) )
@@ -273,7 +273,7 @@ let b:magit_current_commit_msg = []
 "       'CC': prepare a brand new commit message
 "       'CA': get the last commit message
 function! s:mg_get_commit_section()
-	if ( b:magit_current_commit_mode != '' )
+	if ( b:magit_current_commit_mode !=# '' )
 		silent put =''
 		silent put =g:magit_sections.commit
 		call <SID>mg_section_help('commit')
@@ -281,10 +281,10 @@ function! s:mg_get_commit_section()
 
 		let git_dir=magit#git#git_dir()
 		" refresh the COMMIT_EDITMSG file
-		if ( b:magit_current_commit_mode == 'CC' )
+		if ( b:magit_current_commit_mode ==# 'CC' )
 			silent! call magit#utils#system("GIT_EDITOR=/bin/false " .
 						\ g:magit_git_cmd . " -c commit.verbose=no commit -e 2> /dev/null")
-		elseif ( b:magit_current_commit_mode == 'CA' )
+		elseif ( b:magit_current_commit_mode ==# 'CA' )
 			silent! call magit#utils#system("GIT_EDITOR=/bin/false " .
 						\ g:magit_git_cmd . " -c commit.verbose=no commit --amend -e 2> /dev/null")
 		endif
@@ -320,7 +320,7 @@ function! s:mg_search_block(start_pattern, end_pattern, upper_limit_pattern,
 			\ end_pattern_on_cursor)
 
 	let upper_limit=0
-	if ( a:upper_limit_pattern != "" )
+	if ( a:upper_limit_pattern !=# '' )
 		let upper_limit=search(a:upper_limit_pattern, "cbnW")
 	endif
 
@@ -385,7 +385,7 @@ endfunction
 "       commit
 " return no
 function! s:mg_git_commit(mode) abort
-	if ( a:mode == 'CF' )
+	if ( a:mode ==# 'CF' )
 		silent let git_result=magit#utils#system(g:magit_git_cmd .
 					\ " commit --amend -C HEAD")
 	else
@@ -413,7 +413,7 @@ function! s:mg_git_commit(mode) abort
 			endif
 		endif
 
-		if ( a:mode == 'CA' )
+		if ( a:mode ==# 'CA' )
 			let commit_flag.=" --amend "
 		endif
 		let commit_cmd=g:magit_git_cmd . " commit " . commit_flag .
@@ -501,7 +501,7 @@ function! s:mg_create_diff_from_select(select_lines)
 	" ignored. To do so, + lines are simply ignored, - lines are considered as
 	" untouched.
 	" For unstaging, - lines must be ignored and + lines considered untouched.
-	if ( section == 'unstaged' )
+	if ( section ==# 'unstaged' )
 		let remove_line_char = '+'
 		let replace_line_char = '-'
 	else
@@ -516,7 +516,7 @@ function! s:mg_create_diff_from_select(select_lines)
 		elseif ( hunk_line =~ '^'.replace_line_char.'.*' )
 			call add(selection, substitute(hunk_line,
 						\ '^'.replace_line_char.'\(.*\)$', ' \1', ''))
-		elseif ( hunk_line =~ '^ .*' )
+		elseif ( hunk_line =~# '^ .*' )
 			call add(selection, hunk_line)
 		else
 			throw 'visual selection error: ' . hunk_line
@@ -636,7 +636,7 @@ let s:mg_display_functions = {
 " VimagitUpdateFile event is raised
 function! magit#update_buffer(...)
 	let buffer_name=bufname("%")
-	if ( buffer_name !~ 'magit://.*' )
+	if ( buffer_name !~# 'magit://.*' )
 		echoerr "Not in magit buffer but in " . buffer_name
 		return
 	endif
@@ -648,7 +648,7 @@ function! magit#update_buffer(...)
 		let cur_section = a:2
 	endif
 
-	if ( b:magit_current_commit_mode != '' )
+	if ( b:magit_current_commit_mode !=# '' )
 		try
 			let b:magit_current_commit_msg = s:mg_get_commit_msg(1)
 		catch /^out_of_block$/
@@ -699,7 +699,7 @@ function! magit#update_buffer(...)
 
 	call magit#utils#clear_undo()
 
-	if ( b:magit_current_commit_mode != '' && b:magit_commit_newly_open == 1 )
+	if ( b:magit_current_commit_mode !=# '' && b:magit_commit_newly_open == 1 )
 		let commit_section_pat_start='^'.g:magit_sections.commit.'$'
 		silent! let section_line=search(commit_section_pat_start, "w")
 		silent! call cursor(section_line+2+<SID>mg_get_inline_help_line_nb('commit'), 0)
@@ -754,7 +754,7 @@ endfunction
 "     'h': horizontal split
 "     'c': current buffer (should be used when opening vim in vimagit mode
 function! magit#show_magit(display, ...)
-	if ( &filetype == 'netrw' )
+	if ( &filetype ==# 'netrw' )
 		let cur_file_path = b:netrw_curdir
 	else
 		let cur_file = expand("%:p")
@@ -765,12 +765,12 @@ function! magit#show_magit(display, ...)
 	let try_paths = [ cur_file_path, getcwd() ]
 	for path in try_paths
 		let git_dir=magit#git#is_work_tree(path)
-		if ( git_dir != '' )
+		if ( git_dir !=# '' )
 			break
 		endif
 	endfor
 
-	if ( git_dir == '' )
+	if ( git_dir ==# '' )
 		echohl ErrorMsg
 		echom "magit can not find any git repository"
 		echom "make sure that current opened file or vim current directory points to a git repository"
@@ -788,13 +788,13 @@ function! magit#show_magit(display, ...)
 
 	if ( magit_win != 0 )
 		silent execute magit_win."wincmd w"
-	elseif ( a:display == 'v' )
+	elseif ( a:display ==# 'v' )
 		silent execute "vnew " . buffer_name
-	elseif ( a:display == 'h' )
+	elseif ( a:display ==# 'h' )
 		silent execute "new " . buffer_name
-	elseif ( a:display == 'c' )
+	elseif ( a:display ==# 'c' )
 		if ( !bufexists(buffer_name) )
-			if ( bufname("%") == "" )
+			if ( bufname("%") ==# '' )
 				silent keepalt enew
 			else
 				silent enew
@@ -914,9 +914,9 @@ function! s:mg_stage_closed_file(discard)
 		if ( file.is_visible() == 0 ||
 			\ file.is_dir() == 1 )
 			if ( a:discard == 0 )
-				if ( section == 'unstaged' )
+				if ( section ==# 'unstaged' )
 					call magit#git#git_add(magit#utils#add_quotes(filename))
-				elseif ( section == 'staged' )
+				elseif ( section ==# 'staged' )
 					call magit#git#git_reset(magit#utils#add_quotes(filename))
 				else
 					echoerr "Must be in \"" .
@@ -924,8 +924,8 @@ function! s:mg_stage_closed_file(discard)
 								\ g:magit_sections.unstaged . "\" section"
 				endif
 			else
-				if ( section == 'unstaged' )
-					if ( file.status == '?' )
+				if ( section ==# 'unstaged' )
+					if ( file.status ==# '?' )
 						if ( g:magit_discard_untracked_do_delete == 1 )
 							if ( delete(filename) != 0 )
 								echoerr "Can not delete \"" . filename . "\""
@@ -974,13 +974,13 @@ function! magit#stage_block(selection, discard) abort
 	
 	let file = b:state.get_file(section, filename, 0)
 	if ( a:discard == 0 )
-		if ( section == 'unstaged' )
+		if ( section ==# 'unstaged' )
 			if ( file.must_be_added() )
 				call magit#git#git_add(magit#utils#add_quotes(filename))
 			else
 				call magit#git#git_apply(header, a:selection)
 			endif
-		elseif ( section == 'staged' )
+		elseif ( section ==# 'staged' )
 			if ( file.must_be_added() )
 				call magit#git#git_reset(magit#utils#add_quotes(filename))
 			else
@@ -992,7 +992,7 @@ function! magit#stage_block(selection, discard) abort
 						\ g:magit_sections.unstaged . "\" section"
 		endif
 	else
-		if ( section == 'unstaged' )
+		if ( section ==# 'unstaged' )
 			if ( file.must_be_added() )
 				call magit#git#git_checkout(magit#utils#add_quotes(filename))
 			else
@@ -1132,12 +1132,12 @@ endfunction
 "   'CA'/'CF': if in commit section mode, call magit#git_commit, else just set
 "   global state variable b:magit_current_commit_mode,
 function! magit#commit_command(mode)
-	if ( a:mode == 'CF' )
+	if ( a:mode ==# 'CF' )
 		call <SID>mg_git_commit(a:mode)
 	else
 		let section=<SID>mg_get_section()
-		if ( section == 'commit' )
-			if ( b:magit_current_commit_mode == '' )
+		if ( section ==# 'commit' )
+			if ( b:magit_current_commit_mode ==# '' )
 				echoerr "Error, commit section should not be enabled"
 				return
 			endif
@@ -1157,7 +1157,7 @@ endfunction
 " magit#close_commit: cancel for commit mode
 " close commit section if opened
 function! magit#close_commit()
-  if ( b:magit_current_commit_mode == '' )
+  if ( b:magit_current_commit_mode ==# '' )
     return
   endif
 
@@ -1177,7 +1177,7 @@ endfunction
 " it closes the current fold (if any), jump to next hunk and unfold it
 " param[in] dir: can be 'N' (for next) or 'P' (for previous)
 function! magit#jump_hunk(dir)
-	let back = ( a:dir == 'P' ) ? 'b' : ''
+	let back = ( a:dir ==# 'P' ) ? 'b' : ''
 	let line = search("^@@ ", back . 'wn')
 	if ( line != 0 )
 		if ( foldlevel(line('.')) == 2 )
@@ -1237,9 +1237,9 @@ function! magit#jump_to()
 endfunction
 
 function! magit#update_diff(way)
-	if ( a:way == "+" )
+	if ( a:way ==# "+" )
 		let b:magit_diff_context+=1
-	elseif ( a:way == "0" )
+	elseif ( a:way ==# "0" )
 		let b:magit_diff_context=3
 	elseif ( b:magit_diff_context > 1 )
 		let b:magit_diff_context-=1

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -778,7 +778,7 @@ function! magit#show_magit(display, ...)
 		throw 'magit_not_in_git_repo'
 	endif
 
-	let buffer_name='magit://' . git_dir
+	let buffer_name=fnameescape('magit://' . git_dir)
 
 	let magit_win = magit#utils#search_buffer_in_windows(buffer_name)
 

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -628,6 +628,10 @@ function! magit#update_buffer(...)
 		catch /^out_of_block$/
 			let b:magit_current_commit_msg = []
 		endtry
+		setlocal buftype=acwrite
+	else
+		setlocal buftype=nofile
+		setlocal nomodified
 	endif
 	" FIXME: find a way to save folding state. According to help, this won't
 	" help:
@@ -776,7 +780,9 @@ function! magit#show_magit(display, ...)
 	setlocal nobuflisted
 	let &l:foldlevel = b:magit_default_fold_level
 	setlocal filetype=magit
-	"setlocal readonly
+
+	execute "autocmd BufWriteCmd " . buffer_name . " :call magit#commit_command('CC')"
+
 
 	let b:state = deepcopy(g:magit#state#state)
 	" s:magit_commit_mode: global variable which states in which commit mode we are
@@ -1086,6 +1092,8 @@ function! magit#commit_command(mode)
 		else
 			let b:magit_current_commit_mode=a:mode
 			let b:magit_commit_newly_open=1
+			setlocal buftype=acwrite
+			setlocal nomodified
 		endif
 	endif
 	call magit#update_buffer()

--- a/syntax/magit.vim
+++ b/syntax/magit.vim
@@ -2,7 +2,8 @@ if exists("b:current_syntax")
   finish
 endif
 
-execute 'source ' . resolve(expand('<sfile>:p:h')) . '/../common/magit_common.vim'
+let s:vimagit_path = fnameescape(resolve(expand('<sfile>:p:h')))
+execute 'source ' . s:vimagit_path . '/../common/magit_common.vim'
 
 syn case match
 syn sync minlines=50

--- a/test/run.sh
+++ b/test/run.sh
@@ -15,7 +15,7 @@ python -c "import os,sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])
 
 export VIMAGIT_PATH=$(prealpath $1)
 export VADER_PATH=$(prealpath $2)
-export TEST_PATH=$(prealpath $3)
+export TEST_PATH=$(prealpath "$3")
 export VIM_VERSION=$4
 
 if [[ ! ( -d $VIMAGIT_PATH && -d $VADER_PATH && -d $TEST_PATH ) ]]; then
@@ -23,7 +23,7 @@ if [[ ! ( -d $VIMAGIT_PATH && -d $VADER_PATH && -d $TEST_PATH ) ]]; then
 	exit 1
 fi
 
-pushd $TEST_PATH
+pushd "$TEST_PATH"
 git config --local user.email 'tester@vimagit.org'
 git config --local user.name 'vimagit tester'
 export TEST_HEAD_SHA1='origin/vimagit_test-1.4.1'
@@ -62,7 +62,7 @@ for script in ${!test_scripts[@]}; do
 	for filename in "${filename_array[@]}"; do
 		echo ${_TEST_PATHS[@]}
 		for test_path in ${_TEST_PATHS[@]}; do
-			export TEST_SUB_PATH=$(prealpath $TEST_PATH/$test_path)
+			export TEST_SUB_PATH=$(prealpath "$TEST_PATH"/$test_path)
 			export VIMAGIT_TEST_FILENAME="$filename"
 
 			for i in $EOL_TEST; do


### PR DESCRIPTION
Make operators ignore user's `ignorecase` settings and add `abort`
to autoload functions. `abort` forces the function to halt when it
encounters an error.