### PR TITLE
 Check user's commit message length fix #86

### DIFF
--- a/syntax/magit.vim
+++ b/syntax/magit.vim
@@ -12,13 +12,16 @@ syn include @diff syntax/diff.vim
 execute 'syn match titleEntry "' . g:magit_section_re . '\n=\+"'
 hi def link titleEntry Comment
 
+execute 'syn match commitMsgExceed "\(=\+\n.\{50}\)\@<=.*$"'
+hi def link commitMsgExceed Comment
+
 execute 'syn match stashEntry "' . g:magit_stash_re . '"'
 hi def link stashEntry String
 
 execute 'syn match fileEntry "' . g:magit_file_re . '"'
 hi def link fileEntry String
 
-execute 'syn region gitTitle start=/^$\n' . g:magit_section_re . '/ end=/^$/ contains=titleEntry'
+execute 'syn region gitTitle start=/^$\n' . g:magit_section_re . '/ end=/^$/ contains=titleEntry,commitMsgExceed'
 
 execute 'syn region gitStash start=/' . g:magit_stash_re . '/ end=/\%(' .
  \ g:magit_stash_re . '\)\@=/ contains=stashEntry fold'


### PR DESCRIPTION
I find out the solution to let this feature work!
Using the vim regex pattern `\@<=` of this [page](http://vimdoc.sourceforge.net/htmldoc/pattern.html)

The result show like this
![magit ---home-scps950707-github-gittest - vim_006](https://cloud.githubusercontent.com/assets/6916149/22732243/6f343b0e-ee28-11e6-99ae-76367710ea96.png)

jreybert/vimagit#86

