### PR TITLE
only set autocmd once for write command checking

### DIFF
--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -807,6 +807,8 @@ function! magit#show_magit(display, ...)
 	let &l:foldlevel = b:magit_default_fold_level
 	setlocal filetype=magit
 
+	augroup vimagit_buffer
+	autocmd!
 	" catch write command
 	execute "autocmd BufWriteCmd " . buffer_name . " :call magit#commit_command('CC')"
 
@@ -823,6 +825,7 @@ function! magit#show_magit(display, ...)
 	      \ b:magit_current_commit_mode != '' ) |
 	      \   call s:set_mode_read() |
 	      \ endif"
+	augroup END
 
 	let b:state = deepcopy(g:magit#state#state)
 	" s:magit_commit_mode: global variable which states in which commit mode we are


### PR DESCRIPTION
All autocmd should install only once. Normally augroup is used but I don't think our autocmd list will grow enough to justify three more augroup lines.

Fixes #138