### PR TITLE
Easy change split configuration with variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,15 @@ It takes 3 parameters:
       - 'h', curent window is split horizontally, and magit is displayed in
         new buffer
       - 'c', magit is displayed in current buffer
+    user can control type of the split with variable
+    (see [g:magit_split_type](#gmagit_split_type))
   * show_all_files: define how file diffs are shown by default for this session
     (see [g:magit_default_show_all_files](#gmagit_default_show_all_files))
   * foldlevel: set default magit buffer foldlevel for this session
     (see [g:magit_default_fold_level](#gmagit_default_fold_level))
 
 #### :Magit
-Open magit buffer in a vertical split (see [details](magitshow_magit)).
+Open magit buffer in a vertical split by default (see [details](magitshow_magit)).
 
 #### :MagitOnly
 Open magit buffer in current window (see [details](magitshow_magit)).
@@ -502,6 +504,12 @@ nothing else to stage (which means that both Staged and Unstaged sections are
 empty).
 Default value is 0.
 > let g:magit_auto_close=[01]
+
+#### g:magit_split_type
+
+When set to "h", magit will open in a horizontal split.
+Default value is "v".
+> let g:magit_split_type = [hv]
 
 ## Requirements
 

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -23,6 +23,7 @@ let g:magit_show_magit_mapping     = get(g:, 'magit_show_magit_mapping',        
 
 " user options
 let g:magit_enabled                = get(g:, 'magit_enabled',                   1)
+let g:magit_split_type             = get(g:, 'magit_split_type',                "v")
 let g:magit_show_help              = get(g:, 'magit_show_help',                 0)
 let g:magit_default_show_all_files = get(g:, 'magit_default_show_all_files',    1)
 let g:magit_default_fold_level     = get(g:, 'magit_default_fold_level',        1)
@@ -41,7 +42,7 @@ let g:magit_warning_max_lines      = get(g:, 'magit_warning_max_lines',         
 
 let g:magit_git_cmd                = get(g:, 'magit_git_cmd'          ,         "git")
 
-execute "nnoremap <silent> " . g:magit_show_magit_mapping . " :call magit#show_magit('v')<cr>"
+execute "nnoremap <silent> " . g:magit_show_magit_mapping . " :call magit#show_magit(g:magit_split_type)<cr>"
 
 if (g:magit_refresh_gutter == 1 || g:magit_refresh_gitgutter == 1)
   autocmd User VimagitUpdateFile
@@ -1295,7 +1296,7 @@ function! magit#get_current_mode()
 	endif
 endfunction
 
-command! Magit call magit#show_magit('v')
+command! Magit call magit#show_magit(g:magit_split_type)
 command! MagitOnly call magit#show_magit('c')
 
 " }}}


### PR DESCRIPTION
With this user can easily configure split in which vimagit will open. Changes are pretty small, but I think it will be useful.  
Default behavior is the same as before. README updated accordingly.