### PR TITLE
Use cygpath if present to create top level dir for Cygwin/MSYS2 

### DIFF
--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -52,6 +52,9 @@ function! magit#git#is_work_tree(path)
 	try
 		call magit#utils#chdir(a:path)
 		let top_dir=system(g:magit_git_cmd . " rev-parse --show-toplevel")
+    if ( executable("cygpath") )
+      let top_dir = magit#utils#strip(system("cygpath " . top_dir))
+    endif
 		if ( v:shell_error != 0 )
 			return ''
 		endif
@@ -72,6 +75,10 @@ function! magit#git#set_top_dir(path)
 			let top_dir=magit#utils#strip(
 						\ system(g:magit_git_cmd . " rev-parse --show-toplevel")) . "/"
 			let git_dir=magit#utils#strip(system(g:magit_git_cmd . " rev-parse --git-dir")) . "/"
+      if ( executable("cygpath") )
+        let top_dir = magit#utils#strip(system("cygpath " . top_dir))
+        let git_dir = magit#utils#strip(system("cygpath " . git_dir))
+      endif
 		catch 'shell_error'
 			call magit#sys#print_shell_error()
 			throw 'set_top_dir_error'

--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -52,9 +52,9 @@ function! magit#git#is_work_tree(path)
 	try
 		call magit#utils#chdir(a:path)
 		let top_dir=system(g:magit_git_cmd . " rev-parse --show-toplevel")
-    if ( executable("cygpath") )
-      let top_dir = magit#utils#strip(system("cygpath " . top_dir))
-    endif
+		if ( executable("cygpath") )
+			let top_dir = magit#utils#strip(system("cygpath " . top_dir))
+		endif
 		if ( v:shell_error != 0 )
 			return ''
 		endif
@@ -75,10 +75,10 @@ function! magit#git#set_top_dir(path)
 			let top_dir=magit#utils#strip(
 						\ system(g:magit_git_cmd . " rev-parse --show-toplevel")) . "/"
 			let git_dir=magit#utils#strip(system(g:magit_git_cmd . " rev-parse --git-dir")) . "/"
-      if ( executable("cygpath") )
-        let top_dir = magit#utils#strip(system("cygpath " . top_dir))
-        let git_dir = magit#utils#strip(system("cygpath " . git_dir))
-      endif
+			if ( executable("cygpath") )
+				let top_dir = magit#utils#strip(system("cygpath " . top_dir))
+				let git_dir = magit#utils#strip(system("cygpath " . git_dir))
+			endif
 		catch 'shell_error'
 			call magit#sys#print_shell_error()
 			throw 'set_top_dir_error'


### PR DESCRIPTION
git rev-parse --show-topdir command on Git for Windows returns a Windows path which cannot be found if using Vim and Vimagit from Cygwin or MSYS2. This change checks for the presence of the cygpath command if present is used to convert the windows path into a Unix style path compatible with Cygwin and MSYS2.