### PR TITLE
Implemented Branch Checkout (#141)

### DIFF
--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -339,3 +339,9 @@ function! magit#git#get_remote_branch(ref, type)
 		return "none"
 	endtry
 endfunction
+
+
+function! magit#git#get_branches()
+    return magit#sys#system(g:magit_git_cmd . " branch -a")
+endfunction
+

--- a/autoload/magit/mapping.vim
+++ b/autoload/magit/mapping.vim
@@ -9,6 +9,9 @@ let g:magit_commit_fixup_mapping   = get(g:, 'magit_commit_fixup_mapping',      
 let g:magit_close_commit_mapping   = get(g:, 'magit_close_commit_mapping',      'CU' )
 let g:magit_reload_mapping         = get(g:, 'magit_reload_mapping',            'R' )
 let g:magit_edit_mapping           = get(g:, 'magit_edit_mapping',              'E' )
+let g:magit_checkout_mapping       = get(g:, 'magit_checkout_mapping',          'CBB')
+let g:magit_checkout_last_mapping  = get(g:, 'magit_checkout_last_mapping',     'CB-')
+let g:magit_checkout_force_mapping = get(g:, 'magit_checkout_force_mapping',    'CBF')
 
 let g:magit_jump_next_hunk         = get(g:, 'magit_jump_next_hunk',            '<C-N>')
 let g:magit_jump_prev_hunk         = get(g:, 'magit_jump_prev_hunk',            '<C-P>')
@@ -157,6 +160,13 @@ function! magit#mapping#set_default()
 	call s:mg_set_mapping('n', g:magit_jump_prev_hunk,
 				\ "magit#jump_hunk('P')")
 
+    call s:mg_set_mapping('n', g:magit_checkout_mapping,
+                \ "magit#checkout_branch('B')")
+    call s:mg_set_mapping('n', g:magit_checkout_last_mapping,
+                \ "magit#checkout_branch('-')")
+    call s:mg_set_mapping('n', g:magit_checkout_force_mapping,
+                \ "magit#checkout_branch('F')")
+
 	for mapping in g:magit_folding_toggle_mapping
 		" trick to pass '<cr>' in a mapping command without being interpreted
 		let func_arg = ( mapping ==? "<cr>" ) ? '+' : mapping
@@ -227,6 +237,14 @@ function! magit#mapping#set_default()
 \'       modifying the previous commit message',
 \g:magit_close_commit_mapping
 \. '     commit undo, cancel and close current commit message',
+\g:magit_checkout_mapping
+\. '    From stage mode: set branch mode in normal flavor',
+\'       From branch mode: checkout branch on line cursor is on.', 
+\g:magit_checkout_force_mapping
+\. '    From stage mode: set branch mode in force flavor',
+\'       From branch mode: checkout/reset branch on line cursor is on.', 
+\g:magit_checkout_last_mapping
+\. '    From stage mode: checkout previous branch.',
 \g:magit_reload_mapping
 \.'      refresh magit buffer',
 \g:magit_diff_shrink.','.g:magit_diff_enlarge.','.g:magit_diff_reset

--- a/common/magit_common.vim
+++ b/common/magit_common.vim
@@ -7,7 +7,8 @@ let g:magit_sections = {
  \ 'staged':         'Staged changes',
  \ 'unstaged':       'Unstaged changes',
  \ 'commit':         'Commit message',
- \ 'stash':          'Stash list'
+ \ 'stash':          'Stash list',
+ \ 'branches':       'Branch list'
  \ }
 
 let g:magit_section_info = {

--- a/doc/vimagit.txt
+++ b/doc/vimagit.txt
@@ -100,15 +100,26 @@ Commit mode has two flavors.
 
 By the way, you can also perform all stage mode actions in commit mode.
 
+BRANCH MODE                                                *vimagit-branch-mode*
+
+In this mode, the `Branch list` section is open, where you can choose any 
+existing local or remote branch as well as create a new local branch.
+There are two flavors to Branch mode:
+
+* `normal`: selected branch will be created/checked out normally.
+* `force`: selected branch will be created if nonexistant, or reset if existant.
+
 SECTIONS                                                      *vimagit-sections*
 
 IMPORTANT: mappings can have different meanings regarding the cursor position.
 
-There are 5 sections:
+There are 6 sections:
 * Info: this section display some information about the git repository, like
   the current branch and the HEAD commit.
 * Commit message: this section appears in commit mode (see below). It contains
   the message to be committed.
+* Branch list: this section contains all of the current local and remote 
+  brances.
 * Staged changes: this sections contains all staged files/hunks, ready to
   commit.
 * Unstaged changes: this section contains all unstaged and untracked
@@ -216,6 +227,27 @@ section only.
   <CF>      From `stage mode`: amend the staged changes into the previous
             commit, without modifying previous commit message.
 
+
+
+                                    *vimagit-CBB*   *magit#checkout_branch('B')*
+                                    *vimagit-g:magit_checkout_mapping*
+  <CBB>    From `stage mode`, set branch mode in `normal` flavor and show  
+           "Branches" section. When used in `branch mode`, the branch name on
+           the line the cursor is on will be checked out. Created locally if
+           needed. This is equivalent to `git checkout -b <branch> [remote]`
+
+                                    *vimagit-CBF*   *magit#checkout_branch('F')*
+                                    *vimagit-g:magit_checkout_force_mapping*
+  <CBF>    From `stage mode` or `branch mode`, set branching to `force` mode, 
+           and checkout any new or existing branches with <CBF> while the cursor 
+           is on the line of the desired branch. This is equivalent to 
+           `git checkout -B <branch> [remote]`.
+
+                                    *vimagit-CB-*   *magit#checkout_branch('-')*
+                                    *vimagit-g:magit_checkout_last_mapping*
+  <CB->    From `stage mode`, instantly checkout the previous branch. Any 
+           changes are carried along the checkout. This is equivalent to
+           `git checkout -`.
 
 
                                     *vimagit-<C-n>*          *magit#jump_hunk()*

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -249,13 +249,8 @@ function! s:mg_get_commit_section()
 	endif
 endfunction
 
-<<<<<<< HEAD
-" s:mg_get_branches_section: this function writes in current buffer the commit
-" section. It is a commit message, depending on b:magit_current_commit_mode
-=======
 " s:mg_get_branches_section: this function writes in current buffer the branch 
 " section. 
->>>>>>> 39003c0... Implemented Branch Checkout (#141)
 " WARNING: this function writes in file, it should only be called through
 " protected functions like magit#update_buffer
 " param[in] b:magit_show_branches: 

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -249,8 +249,13 @@ function! s:mg_get_commit_section()
 	endif
 endfunction
 
+<<<<<<< HEAD
 " s:mg_get_branches_section: this function writes in current buffer the commit
 " section. It is a commit message, depending on b:magit_current_commit_mode
+=======
+" s:mg_get_branches_section: this function writes in current buffer the branch 
+" section. 
+>>>>>>> 39003c0... Implemented Branch Checkout (#141)
 " WARNING: this function writes in file, it should only be called through
 " protected functions like magit#update_buffer
 " param[in] b:magit_show_branches: 


### PR DESCRIPTION
There are three bindings: `CBB`, `CBF`, and `CB-`. `CBB` is the
equivalent of 'git checkout -b'; `CBF` is the equivalent of 'git
checkout -B', and `CB-` is the equivalent of 'git checkout -'.

I adapted the UI based off of the proposed UI in the issue by changing
from autocompletion(?) of typed branch names to listed branches (remote
and local alike) which can be selected with `CBB`/`CBF`, along with the
option to Close the section as well as create a new local branch.

Inline help and vimagit.txt are updated with details.

Airline 'modes' should work, based on what I can tell, but I cannot confirm it since I do not have airline installed in my config.

EDIT: Sorry for the weird extra commits. Needed to amend a comment-change and the remote did NOT like it. 