### PR TITLE
check_repo() can't use 'count' for a variable name.

### DIFF
--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -312,8 +312,8 @@ function! magit#git#check_repo()
 	try
 		let head_br=magit#git#get_branch_name("HEAD")
 	catch 'shell_error'
-		let count = magit#git#count_object()['count']
-		if ( count != 0 )
+		let object_count = magit#git#count_object()['count']
+		if ( object_count != 0 )
 			return 1
 		endif
 	endtry


### PR DESCRIPTION
Even though it's not prefixed with v:, Vim still regards it as attempting to overwrite it's internal (read-only) variable count.

This is probably only hit when trying to use Vimagit to commit items to a freshly init'ed repo, so most people wouldn't encounter it.