### PR TITLE
Fix very slow update when large submodule

### DIFF
--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -271,10 +271,12 @@ function! magit#git#git_unapply(header, selection, mode)
 	endtry
 endfunction
 
-" magit#git#submodule_status: helper function to return the submodule status
-" return submodule status
-function! magit#git#submodule_status()
-	return magit#sys#system(g:magit_git_cmd . " submodule status")
+" magit#git#submodule_list: helper function to return the submodule list
+" return array of submodule names
+function! magit#git#submodule_list()
+	return map(split(magit#sys#system(
+				\ g:magit_git_cmd . " ls-files --stage | \grep 160000 || true"),
+				\ "\n"), 'split(v:val)[3]')
 endfunction
 
 " magit#git#get_branch_name: get the branch name given a reference

--- a/autoload/magit/utils.vim
+++ b/autoload/magit/utils.vim
@@ -10,7 +10,7 @@ let s:submodule_list = []
 " magit#utils#refresh_submodule_list: this function refresh the List s:submodule_list
 " magit#utils#is_submodule() is using s:submodule_list
 function! magit#utils#refresh_submodule_list()
-	let s:submodule_list = map(split(magit#git#submodule_status(), "\n"), 'split(v:val)[1]')
+	let s:submodule_list = magit#git#submodule_list()
 endfunction
 
 " magit#utils#is_submodule search if dirname is in s:submodule_list 


### PR DESCRIPTION
Until now, vimagit relied on `git submodule status` to get the list of
submodule. As we just want a list of the submodule, and not their
status, this is oversized.

Having linux as a submodule, `git submodule status` can take more than 10
seconds.

This new method is very fast.