### PR TITLE
Let amend mode load previous commit message even if the editor's working dir is outside the repo

### DIFF
--- a/autoload/magit/git.vim
+++ b/autoload/magit/git.vim
@@ -79,7 +79,7 @@ function! magit#git#set_top_dir(path)
 		try
 			let top_dir=magit#utils#strip(
 						\ system(g:magit_git_cmd . " rev-parse --show-toplevel")) . "/"
-			let git_dir=magit#utils#strip(system(g:magit_git_cmd . " rev-parse --git-dir")) . "/"
+			let git_dir=magit#utils#strip(system(g:magit_git_cmd . " rev-parse --absolute-git-dir")) . "/"
 			if ( executable("cygpath") )
 				let top_dir = magit#utils#strip(system("cygpath " . top_dir))
 				let git_dir = magit#utils#strip(system("cygpath " . git_dir))


### PR DESCRIPTION
I often work with repositories that depend on each other, but are meant to reside in sibling directories (I cannot change this structure).
To make grepping all the repositories at once, I usually  start neovim from the common parent directory, but then trying to amend a commit with CA, fails to load the previous message as described in #200.

This pull request tries to address this by invoking  fnamemodify(git_dir, ':p') on the path returned by the previous call to
 git rev-parse --git-dir
making it absolute.

In my tests this approach works when opening the file from:
- the parent directory,
- a sibling directory and,
- a path with an ancestor in common with the containing repository.