### PR TITLE
Display option to modify how the magit window is shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,15 @@ example to your vimrc.
 
 User can define in its prefered vimrc some options.
 
+#### g:magit_show_magit_display
+Choose display setup for magit (default: 'v')
+Possible values:
+     'v': vertical split
+     'h': horizontal split
+     'c': current buffer
+> let g:magit_show_magit_display='v'
+
+
 #### g:magit_enabled
 
 To enable or disable vimagit plugin.

--- a/doc/vimagit.txt
+++ b/doc/vimagit.txt
@@ -168,9 +168,9 @@ MAPPINGS                                                      *vimagit-mappings*
 For each mapping, user can redefine the behavior with its own mapping. Each
 variable is described below as           *vimagit-g:magit_nameofmapping_mapping*
 
-For example, to redefine the <leader>M mapping, user should add this line in
-its |vimrc|:
-let g:magit_show_magit_mapping='m'
+For example, to redefine the <leader>M mapping to <leader>g, add this line in 
+your |vimrc|:
+let g:magit_show_magit_mapping='<leader>g'
 
 Mapping update                                          *vimagit-mapping-update*
 --------------
@@ -178,6 +178,10 @@ Mapping update                                          *vimagit-mapping-update*
 Since vimagit 1.7, jump mappings have changed:
    Jump next hunk : N -> <C-n>
    Jump prev hunk : P -> <C-p>
+
+(Previous behaviour can be restored by redefining the following variables:
+let g:magit_jump_next_hunk='N'
+let g:magit_jump_prev_hunk='P')
 
 Global mappings
 ---------------

--- a/doc/vimagit.txt
+++ b/doc/vimagit.txt
@@ -454,6 +454,14 @@ example to your vimrc.
 
 User can define in its prefered |vimrc| some options.
 
+                                            *vimagit-g:magit_show_magit_display*
+Choose display setup for magit (default: 'v')
+Possible values:
+     'v': vertical split
+     'h': horizontal split
+     'c': current buffer
+let g:magit_show_magit_display='v'
+
                                                        *vimagit-g:magit_enabled*
 To enable or disable vimagit plugin.
 Default value is 1.

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -23,6 +23,8 @@ execute 'source ' . g:vimagit_path . '/../common/magit_common.vim'
 let g:magit_show_magit_mapping     = get(g:, 'magit_show_magit_mapping',        '<leader>M' )
 
 " user options
+" default display: vertical split.
+let g:magit_show_magit_display     = get(g:, 'magit_show_magit_display',       'v')
 let g:magit_enabled                = get(g:, 'magit_enabled',                   1)
 let g:magit_show_help              = get(g:, 'magit_show_help',                 0)
 let g:magit_default_show_all_files = get(g:, 'magit_default_show_all_files',    1)
@@ -48,7 +50,7 @@ let g:magit_warning_max_lines      = get(g:, 'magit_warning_max_lines',         
 
 let g:magit_git_cmd                = get(g:, 'magit_git_cmd'          ,         "git")
 
-execute "nnoremap <silent> " . g:magit_show_magit_mapping . " :call magit#show_magit('v')<cr>"
+execute "nnoremap <silent> " . g:magit_show_magit_mapping . " :call magit#show_magit('" . g:magit_show_magit_display . "')<cr>"
 
 if (g:magit_refresh_gutter == 1 || g:magit_refresh_gitgutter == 1)
   autocmd User VimagitUpdateFile
@@ -1409,7 +1411,7 @@ function! magit#get_current_mode()
 	endif
 endfunction
 
-command! Magit call magit#show_magit('v')
+command! Magit call magit#show_magit(g:magit_show_magit_display)
 command! MagitOnly call magit#show_magit('c')
 
 " }}}


### PR DESCRIPTION
Added an option to choose whether magit splits vertically (default), horizontally, or replace the current buffer upon display.
Documentation and README changed accordingly.
(+ also a few minor clarifications in the available README)