### PR TITLE
feat: add lazy loading support for modern plugin managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,20 +102,117 @@ Thanks for your time.
 
 ## Installation
 
-This plugin follows the standard runtime path structure, and as such it can be installed with a variety of plugin managers:
+This plugin follows the standard runtime path structure, and as such it can be installed with a variety of plugin managers.
 
-- Pathogen  
-  `git clone https://github.com/jreybert/vimagit ~/.vim/bundle/vimagit`  
+### With Lazy Loading (Recommended)
+
+Vimagit supports lazy loading for faster startup. The plugin loads automatically when you press `<leader>M` or run `:Magit`.
+
+#### lazy.nvim (Recommended for Neovim)
+
+**Basic configuration:**
+```lua
+{
+  'jreybert/vimagit',
+  cmd = { 'Magit', 'MagitOnly' },
+  keys = { '<leader>M' },
+}
+```
+
+**With configuration:**
+```lua
+{
+  'jreybert/vimagit',
+  cmd = { 'Magit', 'MagitOnly' },
+  keys = {
+    { '<leader>M', '<cmd>Magit<cr>', desc = 'Open Magit' },
+  },
+  dependencies = {
+    -- Optional: for git sign integration
+    -- 'airblade/vim-gitgutter',
+    -- 'mhinz/vim-signify',
+
+    -- Optional: for statusline integration
+    -- 'vim-airline/vim-airline',
+  },
+  config = function()
+    vim.g.magit_show_magit_display = 'v'  -- 'v' vertical, 'h' horizontal, 'c' current
+    vim.g.magit_default_fold_level = 1
+    vim.g.magit_refresh_gutter = 1
+  end,
+}
+```
+
+**Custom key mapping:**
+```lua
+{
+  'jreybert/vimagit',
+  cmd = { 'Magit', 'MagitOnly' },
+  keys = {
+    { '<leader>G', '<cmd>Magit<cr>', desc = 'Open Magit' },
+  },
+  init = function()
+    vim.g.magit_show_magit_mapping = '<leader>G'
+  end,
+}
+```
+
+#### vim-plug
+
+**With lazy loading:**
+```vim
+Plug 'jreybert/vimagit', { 'on': ['Magit', 'MagitOnly'] }
+```
+
+**Without lazy loading:**
+```vim
+Plug 'jreybert/vimagit'
+```
+
+**Custom key mapping:**
+```vim
+let g:magit_show_magit_mapping = '<leader>G'
+Plug 'jreybert/vimagit', { 'on': ['Magit', 'MagitOnly'] }
+```
+
+#### packer.nvim
+
+```lua
+use {
+  'jreybert/vimagit',
+  cmd = { 'Magit', 'MagitOnly' },
+  keys = { '<leader>M' },
+  config = function()
+    vim.g.magit_default_fold_level = 1
+  end,
+}
+```
+
+#### dein.vim
+
+```vim
+call dein#add('jreybert/vimagit', {
+  \ 'on_cmd': ['Magit', 'MagitOnly'],
+  \ 'on_map': '<leader>M',
+  \ })
+```
+
+### Without Lazy Loading
+
+- **Pathogen**
+  `git clone https://github.com/jreybert/vimagit ~/.vim/bundle/vimagit`
   Remember to run :Helptags to generate help tags
-- NeoBundle  
+
+- **NeoBundle**
   `NeoBundle 'jreybert/vimagit'`
-- Vundle  
+
+- **Vundle**
   `Plugin 'jreybert/vimagit'`
-- Plug  
-  `Plug 'jreybert/vimagit'`
-- VAM  
+
+- **VAM**
   `call vam#ActivateAddons([ 'jreybert/vimagit' ])`
-- manual  
+
+- **manual**
   copy all of the files into your ~/.vim directory
 
 ## Usage

--- a/plugin/magit.vim
+++ b/plugin/magit.vim
@@ -50,16 +50,24 @@ let g:magit_warning_max_lines      = get(g:, 'magit_warning_max_lines',         
 
 let g:magit_git_cmd                = get(g:, 'magit_git_cmd'          ,         "git")
 
-execute "nnoremap <silent> " . g:magit_show_magit_mapping . " :call magit#show_magit('" . g:magit_show_magit_display . "')<cr>"
-
-if (g:magit_refresh_gutter == 1 || g:magit_refresh_gitgutter == 1)
-  autocmd User VimagitUpdateFile
-    \ if ( exists("*gitgutter#process_buffer") ) |
-    \   call gitgutter#process_buffer(bufnr(g:magit_last_updated_buffer), 0) |
-    \ elseif ( exists("*sy#util#refresh_windows") ) |
-    \   call sy#util#refresh_windows() |
-    \ endif
+" Set up global key mapping (supports lazy loading)
+if !hasmapto('<Plug>(magit-show-magit)', 'n')
+  execute "nmap <silent> " . g:magit_show_magit_mapping . " <Plug>(magit-show-magit)"
 endif
+nnoremap <silent> <Plug>(magit-show-magit) :call magit#show_magit(g:magit_show_magit_display)<cr>
+
+" Set up autocommands in an augroup (supports lazy loading)
+augroup vimagit_gitgutter
+  autocmd!
+  if (g:magit_refresh_gutter == 1 || g:magit_refresh_gitgutter == 1)
+    autocmd User VimagitUpdateFile
+      \ if ( exists("*gitgutter#process_buffer") ) |
+      \   call gitgutter#process_buffer(bufnr(g:magit_last_updated_buffer), 0) |
+      \ elseif ( exists("*sy#util#refresh_windows") ) |
+      \   call sy#util#refresh_windows() |
+      \ endif
+  endif
+augroup END
 " }}}
 
 " s:mg_cut_str cut a string given a limit size


### PR DESCRIPTION
Add support for lazy loading with lazy.nvim, vim-plug, packer.nvim, and dein.vim
to improve startup performance. Plugin now loads on-demand when using :Magit
commands or <leader>M keybinding.

Changes:
- Refactor key mapping to use <Plug> pattern for lazy loading compatibility
- Wrap autocommands in augroup for better lifecycle management
- Add comprehensive lazy loading documentation to README.md
- Include configuration examples for all major plugin managers
- Maintain 100% backwards compatibility with existing setups

Benefits:
- Faster Vim/Neovim startup times
- On-demand loading without functionality changes
- Support for optional dependencies (gitgutter, vim-airline)